### PR TITLE
feat(harmonic_sequence): figure-generation and paper-builder scripts

### DIFF
--- a/scripts/build_harmonic_sequence_paper_pdf.py
+++ b/scripts/build_harmonic_sequence_paper_pdf.py
@@ -1,0 +1,182 @@
+"""
+build_harmonic_sequence_paper_pdf.py
+====================================
+Compile docs/papers/harmonic_sequence_use_cases.md to a single PDF using
+the `markdown_pdf` package (GitHub-flavoured Markdown via mistune + WeasyPrint).
+
+Run:
+    python scripts/build_harmonic_sequence_paper_pdf.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from markdown_pdf import MarkdownPdf, Section
+
+ROOT = Path(__file__).resolve().parents[1]
+PAPER_MD = ROOT / "docs" / "papers" / "harmonic_sequence_use_cases.md"
+PAPER_PDF = ROOT / "docs" / "papers" / "harmonic_sequence_use_cases.pdf"
+
+
+# ---------------------------------------------------------------------------
+# Pre-process the markdown so paths and links work in the PDF
+# ---------------------------------------------------------------------------
+
+def preprocess(md_text: str) -> str:
+    """Rewrite relative image paths to be relative to the markdown file.
+
+    The markdown lives at docs/papers/harmonic_sequence_use_cases.md, and
+    images reference figures/NN_*.png — that's already relative to the
+    markdown file, so it works directly with markdown_pdf when we pass
+    the file's directory as the resource root via Section(root=...).
+
+    We do strip the worktree-relative `../../` repo-source links because
+    they don't resolve to anything browseable from a PDF (they were
+    GitHub navigation links). Leave them as text references.
+    """
+    # Convert `[label](../../path/to/file.py:LINE)` markdown links to a
+    # plain monospace `label` followed by the path in parentheses. This
+    # keeps the readable label while removing the broken-in-PDF link.
+    pattern = re.compile(r"\[([^\]]+)\]\((\.\./\.\./[^\)]+)\)")
+    md_text = pattern.sub(r"`\1` _(\2)_", md_text)
+    # Same for `[label](figures/...)` — those WORK so leave them.
+    return md_text
+
+
+# ---------------------------------------------------------------------------
+# CSS for clean printable layout
+# ---------------------------------------------------------------------------
+
+CSS = """
+@page {
+    size: A4;
+    margin: 1.8cm 1.6cm;
+}
+body {
+    font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    font-size: 10.5pt;
+    line-height: 1.42;
+    color: #222;
+}
+h1 {
+    font-size: 18pt;
+    color: #1a4480;
+    border-bottom: 2px solid #1a4480;
+    padding-bottom: 4px;
+    margin-top: 14pt;
+    page-break-before: auto;
+}
+h2 {
+    font-size: 13.5pt;
+    color: #1a4480;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 3px;
+    margin-top: 16pt;
+}
+h3 {
+    font-size: 11.5pt;
+    color: #1f3a5f;
+    margin-top: 12pt;
+}
+h4 {
+    font-size: 10.5pt;
+    color: #1f3a5f;
+}
+p {
+    margin: 6pt 0;
+    text-align: justify;
+}
+img {
+    max-width: 100%;
+    display: block;
+    margin: 8pt auto;
+    page-break-inside: avoid;
+}
+pre, code {
+    font-family: "Cascadia Mono", "Consolas", "Menlo", monospace;
+    font-size: 9pt;
+}
+pre {
+    background: #f4f6fa;
+    border: 1px solid #d3dae3;
+    border-radius: 3px;
+    padding: 8pt 10pt;
+    line-height: 1.30;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    page-break-inside: avoid;
+}
+code {
+    background: #f4f6fa;
+    padding: 1px 3px;
+    border-radius: 2px;
+}
+pre code {
+    background: transparent;
+    padding: 0;
+}
+table {
+    border-collapse: collapse;
+    margin: 10pt 0;
+    font-size: 9.5pt;
+    width: 100%;
+}
+th, td {
+    border: 1px solid #c9d2dc;
+    padding: 4pt 6pt;
+    text-align: left;
+}
+th {
+    background: #eef3f8;
+    font-weight: 600;
+}
+blockquote {
+    border-left: 3px solid #1a4480;
+    background: #f4f6fa;
+    margin: 8pt 0;
+    padding: 4pt 10pt;
+    color: #444;
+}
+hr {
+    border: 0;
+    border-top: 1px solid #ccc;
+    margin: 14pt 0;
+}
+em { color: #1a4480; }
+strong { color: #111; }
+a { color: #1a4480; text-decoration: none; }
+"""
+
+
+def main() -> int:
+    print(f"Reading {PAPER_MD.relative_to(ROOT)}...")
+    md_text = PAPER_MD.read_text(encoding="utf-8")
+    md_text = preprocess(md_text)
+
+    pdf = MarkdownPdf(toc_level=2, mode="gfm-like")
+    pdf.meta["title"] = "Modelling temporal harmonic structure in biosignals"
+    pdf.meta["author"] = "biotuner.harmonic_sequence"
+    pdf.meta["subject"] = (
+        "Use-case survey of the biotuner.harmonic_sequence module"
+    )
+
+    # The Section's `root` parameter tells markdown_pdf where to resolve
+    # relative image/asset paths from. We point it at docs/papers/ so
+    # `figures/NN_*.png` references work out of the box.
+    pdf.add_section(
+        Section(md_text, root=str(PAPER_MD.parent)),
+        user_css=CSS,
+    )
+
+    print(f"Writing {PAPER_PDF.relative_to(ROOT)}...")
+    pdf.save(str(PAPER_PDF))
+
+    size_mb = PAPER_PDF.stat().st_size / 1e6
+    print(f"  done. PDF size: {size_mb:.2f} MB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_harmonic_sequence_advanced_cases.py
+++ b/scripts/generate_harmonic_sequence_advanced_cases.py
@@ -1,0 +1,654 @@
+"""
+generate_harmonic_sequence_advanced_cases.py
+============================================
+Companion script producing the "showcase & applications" figures used in the
+second half of docs/papers/harmonic_sequence_use_cases.md.
+
+Five scenarios capture qualitatively different harmonic dynamics:
+
+    A. STABLE         — meditation baseline: same tuning + noise
+    B. DRIFT          — slow continuous deformation (major -> minor)
+    C. CYCLE          — categorical regime cycling (major <-> minor <-> harm7)
+    D. OSCILLATION    — sinusoidal blend between two tunings (DMD goldmine)
+    E. PERTURBED      — long stable epoch + abrupt event
+
+Each scenario is run through the full HarmonicSequenceAnalyzer, and we draw
+side-by-side comparisons highlighting what each modelling approach reveals.
+
+Run:
+    python scripts/generate_harmonic_sequence_advanced_cases.py
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from biotuner.harmonic_sequence import HarmonicSequenceAnalyzer
+
+OUT = ROOT / "docs" / "papers" / "figures"
+OUT.mkdir(parents=True, exist_ok=True)
+
+plt.rcParams.update({
+    "figure.dpi": 110, "savefig.dpi": 140, "font.size": 9,
+    "axes.spines.top": False, "axes.spines.right": False,
+})
+
+# Note: the unison 1.0 maps to cents=0, which sits on the lower histogram
+# edge. Any negative-direction jitter (~half of all draws) would push it
+# below 0 cents and get silently dropped by the histogram, distorting
+# per-row normalisation and inflating Wasserstein flux. We drop the unison
+# from all base scales — it is included automatically by histogram_to_ratios
+# at decode time anyway.
+JUST_MAJOR = [9/8, 5/4, 4/3, 3/2, 5/3, 15/8]
+JUST_MINOR = [9/8, 6/5, 4/3, 3/2, 8/5, 9/5]
+HARM_7     = [9/8, 5/4, 11/8, 3/2, 7/4, 15/8]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenario constructors
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _jitter(rng, base, sigma=0.0003):
+    return [float(x * (1.0 + sigma * rng.standard_normal())) for x in base]
+
+
+def scenario_stable(T: int = 32, seed: int = 0):
+    """A. Stable: same just-major tuning every frame, tiny noise."""
+    rng = np.random.default_rng(seed)
+    return [_jitter(rng, JUST_MAJOR) for _ in range(T)]
+
+
+def scenario_drift(T: int = 32, seed: int = 0):
+    """B. Drift: continuous linear interpolation JUST_MAJOR -> JUST_MINOR."""
+    rng = np.random.default_rng(seed)
+    out = []
+    for t in range(T):
+        a = t / (T - 1)
+        base = [(1 - a) * x + a * y for x, y in zip(JUST_MAJOR, JUST_MINOR)]
+        out.append(_jitter(rng, base))
+    return out
+
+
+def scenario_cycle(T: int = 36, seed: int = 0):
+    """C. Categorical cycling: 3 frames each of major / minor / harm7, looped."""
+    rng = np.random.default_rng(seed)
+    regimes = [JUST_MAJOR, JUST_MINOR, HARM_7]
+    out = []
+    for c in range(T // 9):
+        for base in regimes:
+            for _ in range(3):
+                out.append(_jitter(rng, base))
+    return out
+
+
+def scenario_oscillation(T: int = 48, period: int = 8, seed: int = 0):
+    """D. Sinusoidal blend major <-> minor with given period (in frames)."""
+    rng = np.random.default_rng(seed)
+    out = []
+    for t in range(T):
+        a = 0.5 * (1 + np.sin(2 * np.pi * t / period))
+        base = [(1 - a) * x + a * y for x, y in zip(JUST_MAJOR, JUST_MINOR)]
+        out.append(_jitter(rng, base))
+    return out
+
+
+def scenario_perturbed(T: int = 40, event_at: int = 24, seed: int = 0):
+    """E. Stable baseline then abrupt switch to a different tuning."""
+    rng = np.random.default_rng(seed)
+    out = []
+    for t in range(T):
+        base = JUST_MAJOR if t < event_at else HARM_7
+        out.append(_jitter(rng, base))
+    return out
+
+
+SCENARIOS = {
+    "Stable": scenario_stable(),
+    "Drift": scenario_drift(),
+    "Cycle": scenario_cycle(),
+    "Oscillation": scenario_oscillation(),
+    "Perturbed": scenario_perturbed(),
+}
+SCEN_COLOURS = {
+    "Stable":      "#4C72B0",
+    "Drift":       "#55A868",
+    "Cycle":       "#C44E52",
+    "Oscillation": "#8172B2",
+    "Perturbed":   "#CCB974",
+}
+
+
+def fit_analyzer(ratios_list, n_states="auto", auto_k_range=(2, 6)):
+    az = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list, n_hist_bins=240)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        # Fit per approach with sensible per-scenario parameters
+        az.fit_markov(n_states=n_states, auto_k_range=auto_k_range)
+        az.fit_wasserstein()
+        az.fit_latent(latent_dim=3)
+        try:
+            az.fit_topology(scalar_key="harmsim", embedding_dim=3, delay=1)
+        except Exception:
+            pass
+        try:
+            az.fit_dmd(use_histograms=True)
+        except Exception:
+            pass
+        try:
+            az.fit_grammar(n_gram=2)
+        except Exception:
+            pass
+    return az
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 8 — Scenarios overview (4 scenarios x 3 panels each)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_scenarios_overview():
+    scenario_names = ["Stable", "Drift", "Cycle", "Oscillation"]
+    # First pass: fit all analyzers with a FIXED K=3 (apples-to-apples
+    # transition entropy across scenarios).
+    fits = {}
+    flux_max_all = 0.0
+    for name in scenario_names:
+        az = fit_analyzer(SCENARIOS[name], n_states=3)
+        fits[name] = az
+        flux_max_all = max(flux_max_all, float(az.wasserstein.flux_.max()))
+
+    fig, axes = plt.subplots(
+        nrows=len(scenario_names), ncols=3,
+        figsize=(16, 13),
+        gridspec_kw={"width_ratios": [2.4, 2.6, 1.8],
+                     "hspace": 0.70, "wspace": 0.30},
+    )
+    for row, name in enumerate(scenario_names):
+        ratios = SCENARIOS[name]
+        az = fits[name]
+        H = az.histograms
+        T = H.shape[0]
+        flux = az.wasserstein.flux_
+        labels = az.markov.state_labels_
+
+        # column 0: histogram heatmap
+        ax = axes[row, 0]
+        ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                   extent=[0, T, 0, 1200])
+        ax.set_ylabel("cents")
+        ax.set_title(f"{name}: encoded histograms", fontsize=10)
+        if row == len(scenario_names) - 1:
+            ax.set_xlabel("frame")
+
+        # column 1: flux + Markov state strip (shared y-axis across rows)
+        ax = axes[row, 1]
+        ax.plot(np.arange(len(flux)), flux, color="black", lw=1.4)
+        ax.set_ylabel("$W_1$ flux (bin units)")
+        ax.set_title(f"{name}: flux + Markov states  "
+                      f"(K={az.markov.n_states}, "
+                      f"H={az.markov.transition_entropy_:.2f} bits)", fontsize=10)
+        if row == len(scenario_names) - 1:
+            ax.set_xlabel("frame")
+
+        # Overlay Markov state strip below the flux line; share y-scale
+        strip_h = max(flux_max_all * 0.10, 0.5)
+        ymin = -strip_h * 1.4
+        cmap_st = plt.get_cmap("tab10")
+        for t in range(T):
+            ax.add_patch(plt.Rectangle((t - 0.5, ymin), 1, strip_h,
+                                        color=cmap_st(int(labels[t]) % 10)))
+        ax.set_ylim(ymin - strip_h * 0.2, flux_max_all * 1.10)
+        ax.set_xlim(0, T)
+
+        # column 2: latent 2D scatter
+        ax = axes[row, 2]
+        Z = az.latent.trajectory()
+        sc = ax.scatter(Z[:, 0], Z[:, 1], c=np.arange(T), cmap="viridis",
+                         s=32, edgecolor="white", lw=0.5)
+        ax.plot(Z[:, 0], Z[:, 1], color="grey", lw=0.4, alpha=0.4)
+        evr_sum = az.latent.explained_variance_ratio_[:2].sum()
+        ax.set_title(f"{name}: PC1-PC2  ({evr_sum:.0%} var)", fontsize=10)
+        ax.set_xlabel("PC1"); ax.set_ylabel("PC2")
+        if row == 0:
+            cb = fig.colorbar(sc, ax=ax, fraction=0.06, pad=0.04)
+            cb.set_label("frame", fontsize=8)
+
+    fig.suptitle("Figure 8 — Four scenarios, four signatures",
+                  fontsize=12, y=0.995)
+    fig.savefig(OUT / "08_scenarios_overview.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 08_scenarios_overview.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 9 — DMD on an oscillatory signal
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_dmd_oscillation():
+    ratios = scenario_oscillation(T=64, period=8, seed=1)
+    az = HarmonicSequenceAnalyzer.from_ratios_list(ratios)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        az.fit_dmd(use_histograms=True)
+        az.fit_latent(latent_dim=3)
+    dmd = az.dmd
+    eigs = dmd.eigenvalues_
+
+    fig = plt.figure(figsize=(15, 5.2))
+    gs = fig.add_gridspec(1, 3, width_ratios=[1.0, 1.5, 1.4], wspace=0.45,
+                           left=0.07, right=0.97, bottom=0.16, top=0.85)
+
+    # (a) eigenvalues on the unit circle
+    ax = fig.add_subplot(gs[0, 0])
+    theta = np.linspace(0, 2 * np.pi, 200)
+    ax.plot(np.cos(theta), np.sin(theta), color="grey", lw=0.8, ls="--")
+    osc, idx = dmd.oscillatory_modes(threshold=0.1)
+    is_osc = np.zeros(len(eigs), dtype=bool); is_osc[idx] = True
+    ax.scatter(eigs[~is_osc].real, eigs[~is_osc].imag,
+                s=70, color="#888", alpha=0.7, label="decaying")
+    ax.scatter(eigs[is_osc].real, eigs[is_osc].imag,
+                s=140, color="crimson", marker="*",
+                label=f"on unit circle ({len(idx)})")
+    ax.set_xlim(-1.4, 1.4); ax.set_ylim(-1.4, 1.4)
+    ax.set_aspect("equal")
+    ax.axhline(0, color="grey", lw=0.4); ax.axvline(0, color="grey", lw=0.4)
+    ax.set_xlabel(r"Re($\lambda$)"); ax.set_ylabel(r"Im($\lambda$)")
+    ax.set_title("(a) DMD spectrum")
+    ax.legend(frameon=False, fontsize=8, loc="lower left")
+
+    # (b) reconstructed vs observed first PC over time
+    ax = fig.add_subplot(gs[0, 1])
+    # ground-truth: average cents (centroid of histogram), as a 1-d signal
+    H = az.histograms
+    bin_centers_cents = (np.arange(H.shape[1]) + 0.5) * (1200 / H.shape[1])
+    centroid = (H * bin_centers_cents).sum(axis=1) / np.maximum(H.sum(axis=1), 1e-9)
+    ax.plot(centroid, color="black", lw=1.3, label="observed centroid")
+    # forecast 16 steps from the end and overlay
+    n_fwd = 16
+    X_pred = dmd.reconstruct(n_steps=n_fwd)             # (16, 10) in PCA space
+    # Invert PCA via the stored PCA via a small helper:
+    # we don't have direct access; reconstruct returns the same space DMD was fit in.
+    # Build a faithful 1-D summary by projecting both observed PCA and predicted PCA
+    # onto the leading PC and re-using the centroid-correlated direction.
+    # Simpler: compute "predicted centroid" from the reconstruction's first column.
+    pred_signal = X_pred[:, 0]
+    # Align scales so they overlay visibly
+    obs_pc1 = (H - H.mean(axis=0)).dot(
+        np.linalg.svd(H - H.mean(axis=0), full_matrices=False)[2][0]
+    )
+    obs_pc1_norm = (obs_pc1 - obs_pc1.mean()) / (obs_pc1.std() + 1e-9)
+    pred_norm = (pred_signal - pred_signal.mean()) / (pred_signal.std() + 1e-9)
+    ax2 = ax.twinx()
+    ax2.plot(obs_pc1_norm, color="#888", lw=1.0, ls="--", alpha=0.8,
+              label="observed PC1 (scaled)")
+    ax2.plot(np.arange(len(obs_pc1_norm),
+                       len(obs_pc1_norm) + n_fwd),
+              pred_norm, color="crimson", lw=1.6, label="DMD forecast")
+    ax2.axvline(len(obs_pc1_norm) - 0.5, color="black", lw=0.7, ls=":")
+    ax2.set_ylabel("PC1 (z-score)")
+    ax.set_xlabel("frame")
+    ax.set_ylabel("centroid (cents)")
+    ax.set_title("(b) Observed centroid + 16-step DMD forecast on PC1")
+    h1, l1 = ax.get_legend_handles_labels()
+    h2, l2 = ax2.get_legend_handles_labels()
+    ax2.legend(h1 + h2, l1 + l2, frameon=False, fontsize=8, loc="upper left")
+
+    # (c) period estimate from dominant eigenvalue
+    ax = fig.add_subplot(gs[0, 2])
+    # Sort eigenvalues by closeness to unit circle
+    dist = np.abs(np.abs(eigs) - 1.0)
+    order = np.argsort(dist)
+    top = order[:4]
+    ax.scatter(np.abs(eigs[top]), np.abs(dmd.frequencies_[top]),
+                s=80, c="crimson")
+    # Annotate inferred period (frames per cycle)
+    for i, k in enumerate(top):
+        freq = np.abs(dmd.frequencies_[k])
+        if freq > 1e-6:
+            period_est = 2 * np.pi / freq
+            ax.annotate(f"mode {k}: period ≈ {period_est:.1f} frames",
+                         (np.abs(eigs[k]), np.abs(dmd.frequencies_[k])),
+                         xytext=(8, 0), textcoords="offset points", fontsize=8)
+    ax.set_xlabel(r"$|\lambda|$  (closer to 1 = persistent)")
+    ax.set_ylabel(r"$|\mathrm{Im}\log\lambda|$  (oscillation rate)")
+    ax.set_title("(c) Top oscillatory modes and inferred periods")
+
+    fig.suptitle("Figure 9 — DMD finds the 8-frame oscillation in the data",
+                  fontsize=12, y=0.96)
+    fig.savefig(OUT / "09_dmd_oscillation.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 09_dmd_oscillation.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 10 — Topology: stable vs cycling vs oscillating
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_topology_scenarios():
+    scenario_pick = ["Stable", "Cycle", "Oscillation"]
+    fig, axes = plt.subplots(2, len(scenario_pick), figsize=(15, 9),
+                              gridspec_kw={"hspace": 0.40, "wspace": 0.35,
+                                           "left": 0.07, "right": 0.97,
+                                           "top": 0.92, "bottom": 0.08})
+    for col, name in enumerate(scenario_pick):
+        ratios = (scenario_oscillation(T=64, period=8) if name == "Oscillation"
+                   else SCENARIOS[name])
+        az = HarmonicSequenceAnalyzer.from_ratios_list(ratios)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            az.fit_topology(scalar_key="harmsim", embedding_dim=3, delay=1)
+
+        top = az.topology
+        cloud = top.takens_embedding_
+        beta = top.betti_numbers_
+        fp = top.session_fingerprint()
+
+        ax = axes[0, col]
+        sc = ax.scatter(cloud[:, 0], cloud[:, 1],
+                         c=np.arange(len(cloud)), cmap="viridis",
+                         s=42, edgecolor="white", lw=0.6)
+        ax.plot(cloud[:, 0], cloud[:, 1], color="grey", lw=0.4, alpha=0.4)
+        ax.set_title(f"{name}: Takens cloud  (β0={beta[0]})", fontsize=10)
+        ax.set_xlabel("x(t)"); ax.set_ylabel("x(t+1)")
+        if col == len(scenario_pick) - 1:
+            cb = fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.04)
+            cb.set_label("frame", fontsize=8)
+
+        ax = axes[1, col]
+        diagrams = top.persistence_diagram_
+        max_finite = 0.0
+        for dim, dgm in enumerate(diagrams):
+            finite = dgm[np.isfinite(dgm[:, 1])]
+            if len(finite):
+                max_finite = max(max_finite, finite[:, 1].max())
+                ax.scatter(finite[:, 0], finite[:, 1], s=35, alpha=0.8,
+                            label=f"H{dim}")
+        lims = [0, max_finite * 1.1 if max_finite > 0 else 1]
+        ax.plot(lims, lims, color="grey", lw=0.5, ls="--")
+        ax.set_xlim(lims); ax.set_ylim(lims)
+        ax.set_xlabel("birth"); ax.set_ylabel("death")
+        ax.set_title(
+            f"Persistence  (fp = {np.round(fp[:3], 2).tolist()})",
+            fontsize=9,
+        )
+        ax.legend(frameon=False, fontsize=8)
+
+    fig.suptitle("Figure 10 — Topology distinguishes stable / cyclic / "
+                  "oscillating dynamics",
+                  fontsize=12, y=0.995)
+    fig.savefig(OUT / "10_topology_scenarios.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 10_topology_scenarios.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 11 — Application: stimulus / event detection (PERTURBED scenario)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_application_event_detection():
+    EVENT_AT = 24
+    ratios = scenario_perturbed(T=40, event_at=EVENT_AT, seed=3)
+    az = fit_analyzer(ratios, n_states=2)
+    H = az.histograms
+    T = H.shape[0]
+    flux = az.wasserstein.flux_
+    labels = az.markov.state_labels_
+
+    # Build a simple z-score threshold detector
+    z = (flux - flux.mean()) / (flux.std() + 1e-9)
+    detected = np.where(z > 2.0)[0]
+
+    fig, axes = plt.subplots(3, 1, figsize=(11, 7.0),
+                              gridspec_kw={"height_ratios": [2.0, 1.4, 0.7],
+                                           "hspace": 0.35})
+
+    # (a) histogram heatmap with event marker
+    ax = axes[0]
+    im = ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                    extent=[0, T, 0, 1200])
+    ax.axvline(EVENT_AT, color="cyan", lw=1.6, ls="--", alpha=0.9,
+                label=f"ground-truth event @ t={EVENT_AT}")
+    for d in detected:
+        ax.axvline(d + 0.5, color="red", lw=1.0, ls=":", alpha=0.8)
+    ax.set_ylabel("cents")
+    ax.set_title("(a) Encoded histograms  (cyan = ground-truth event, "
+                  "red dotted = z(flux)>2)")
+    ax.legend(loc="upper right", frameon=False, fontsize=8)
+    fig.colorbar(im, ax=ax, pad=0.01)
+
+    # (b) flux time series with detection threshold
+    ax = axes[1]
+    ax.plot(np.arange(len(flux)), flux, color="black", lw=1.4)
+    threshold = flux.mean() + 2.0 * flux.std()
+    ax.axhline(threshold, color="red", lw=0.8, ls="--",
+                label=f"μ + 2σ = {threshold:.2f}")
+    ax.axvline(EVENT_AT - 0.5, color="cyan", lw=1.4, ls="--", alpha=0.9)
+    for d in detected:
+        ax.scatter(d, flux[d], s=80, color="red", zorder=5)
+    ax.set_xlim(0, T)
+    ax.set_ylabel("$W_1$ flux")
+    ax.set_xlabel("")
+    ax.set_title(f"(b) Wasserstein flux detects the event "
+                  f"(detection latency: {detected[0] - EVENT_AT + 1 if len(detected) else 'N/A'} frames)")
+    ax.legend(loc="upper left", frameon=False, fontsize=8)
+
+    # (c) Markov state strip
+    ax = axes[2]
+    cmap_st = plt.get_cmap("tab10")
+    for t in range(T):
+        ax.add_patch(plt.Rectangle((t, 0), 1, 1,
+                                    color=cmap_st(int(labels[t]) % 10)))
+    ax.axvline(EVENT_AT, color="cyan", lw=1.6, ls="--", alpha=0.9)
+    ax.set_xlim(0, T); ax.set_ylim(0, 1); ax.set_yticks([])
+    ax.set_xlabel("frame"); ax.set_title("(c) Discovered Markov states")
+
+    fig.suptitle("Figure 11 — Application: detecting a stimulus event "
+                  "from harmonic flux", fontsize=12, y=0.995)
+    fig.savefig(OUT / "11_application_event_detection.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 11_application_event_detection.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 12 — Application: session fingerprinting across scenarios
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_application_fingerprinting():
+    """Compute compact per-session fingerprints, then plot them as a grid."""
+    rows = []
+    for name in ["Stable", "Drift", "Cycle", "Oscillation", "Perturbed"]:
+        ratios = SCENARIOS[name]
+        az = fit_analyzer(ratios, n_states="auto", auto_k_range=(2, 5))
+        flux = az.wasserstein.flux_
+        beta = az.topology.betti_numbers_
+        evr = az.latent.explained_variance_ratio_
+        eigs_abs = np.abs(az.dmd.eigenvalues_) if az.dmd is not None else np.array([])
+        osc_frac = float((np.abs(eigs_abs - 1.0) < 0.1).mean()) if len(eigs_abs) else 0.0
+        rows.append([
+            float(flux.mean()),
+            float(flux.std()),
+            float(az.markov.n_states),
+            float(az.markov.transition_entropy_),
+            float(evr[:2].sum()),
+            float(beta[0]),
+            float(osc_frac),
+            float(az.grammar.transition_entropy_) if az.grammar is not None else 0.0,
+        ])
+    rows = np.array(rows)
+    metric_names = [
+        "flux_mean", "flux_std", "K_markov", "H_markov",
+        "var_PC1+2", "beta0", "osc_frac", "H_grammar",
+    ]
+    scen_names = list(SCENARIOS.keys())
+
+    # Normalise per column for fair colour scaling
+    rows_n = (rows - rows.min(axis=0)) / (rows.max(axis=0) - rows.min(axis=0) + 1e-9)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.2),
+                              gridspec_kw={"width_ratios": [2.0, 1.2],
+                                           "wspace": 0.35})
+    ax = axes[0]
+    im = ax.imshow(rows_n, aspect="auto", cmap="viridis")
+    ax.set_xticks(range(len(metric_names)))
+    ax.set_xticklabels(metric_names, rotation=35, ha="right", fontsize=8)
+    ax.set_yticks(range(len(scen_names)))
+    ax.set_yticklabels(scen_names)
+    # Print raw values on cells
+    for i in range(rows.shape[0]):
+        for j in range(rows.shape[1]):
+            txt = f"{rows[i, j]:.2f}"
+            ax.text(j, i, txt, ha="center", va="center", fontsize=7.5,
+                     color="white" if rows_n[i, j] > 0.55 else "black")
+    ax.set_title("(a) Per-scenario fingerprints  (raw values shown, "
+                  "colour = column-normalised)")
+    fig.colorbar(im, ax=ax, fraction=0.035, pad=0.02)
+
+    # Radar plot of 4 chosen metrics for visual distinction
+    ax = axes[1]
+    chosen = ["flux_mean", "H_markov", "var_PC1+2", "beta0"]
+    idx = [metric_names.index(c) for c in chosen]
+    angles = np.linspace(0, 2 * np.pi, len(chosen) + 1)
+    ax = fig.add_subplot(1, 2, 2, projection="polar")
+    fig.delaxes(axes[1])
+    for i, name in enumerate(scen_names):
+        vals = rows_n[i, idx].tolist() + [rows_n[i, idx[0]]]
+        ax.plot(angles, vals, color=SCEN_COLOURS[name], lw=1.4, label=name)
+        ax.fill(angles, vals, color=SCEN_COLOURS[name], alpha=0.10)
+    ax.set_xticks(angles[:-1]); ax.set_xticklabels(chosen, fontsize=8)
+    ax.set_yticklabels([])
+    ax.set_title("(b) Normalised fingerprint radar", pad=18)
+    ax.legend(loc="upper right", bbox_to_anchor=(1.45, 1.05),
+               fontsize=8, frameon=False)
+
+    fig.suptitle("Figure 12 — Application: scenario fingerprints "
+                  "distinguish recording types", fontsize=12, y=1.02)
+    fig.savefig(OUT / "12_application_fingerprinting.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 12_application_fingerprinting.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 13 — Application: cross-session similarity (W1 + Levenshtein)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_application_similarity():
+    """Build a 5x5 similarity matrix between sessions using two metrics."""
+    scen_names = list(SCENARIOS.keys())
+    n = len(scen_names)
+
+    # Fit analyzers and align histogram lengths (truncate to min T)
+    azs = {name: fit_analyzer(SCENARIOS[name], n_states="auto",
+                                auto_k_range=(2, 5)) for name in scen_names}
+    Ts = [az.histograms.shape[0] for az in azs.values()]
+    T_min = min(Ts)
+
+    # Mean Wasserstein between full histograms via centroid distance:
+    # Use the mean of per-row Wasserstein already in distance_matrix_
+    # Cross-session: build a pairwise mean-histogram W1.
+    from scipy.stats import wasserstein_distance
+    mean_hists = {name: azs[name].histograms[:T_min].mean(axis=0)
+                  for name in scen_names}
+    bin_centers = np.arange(240, dtype=float)
+    W = np.zeros((n, n))
+    for i, ni in enumerate(scen_names):
+        for j, nj in enumerate(scen_names):
+            W[i, j] = wasserstein_distance(bin_centers, bin_centers,
+                                            mean_hists[ni], mean_hists[nj])
+
+    # Levenshtein on grammar chord sequences (truncate to T_min)
+    L = np.zeros((n, n))
+    for i, ni in enumerate(scen_names):
+        for j, nj in enumerate(scen_names):
+            si = azs[ni].grammar.chord_sequence_[:T_min]
+            sj = azs[nj].grammar.chord_sequence_[:T_min]
+            L[i, j] = azs[ni].grammar.levenshtein(si, sj)
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4.3),
+                              gridspec_kw={"wspace": 0.4})
+    for ax, M, title, cmap_name in [
+        (axes[0], W, "Mean-histogram $W_1$ distance", "viridis"),
+        (axes[1], L, "Grammar chord-sequence Levenshtein", "plasma"),
+    ]:
+        im = ax.imshow(M, cmap=cmap_name)
+        ax.set_xticks(range(n)); ax.set_xticklabels(scen_names, rotation=35,
+                                                      ha="right", fontsize=9)
+        ax.set_yticks(range(n)); ax.set_yticklabels(scen_names, fontsize=9)
+        for i in range(n):
+            for j in range(n):
+                ax.text(j, i, f"{M[i, j]:.1f}",
+                         ha="center", va="center", fontsize=8,
+                         color="white" if (M[i, j] > M.max() * 0.55) else "black")
+        ax.set_title(title)
+        fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    fig.suptitle("Figure 13 — Application: pairwise session similarity "
+                  "via two complementary metrics", fontsize=12, y=1.02)
+    fig.savefig(OUT / "13_application_similarity.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 13_application_similarity.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 14 — Application: latent-space morphing between two recorded states
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_application_morphing():
+    """Pick two anchor frames in the Cycle scenario and morph between them
+    using BOTH Wasserstein interpolation and latent-space interpolation."""
+    ratios = SCENARIOS["Cycle"]
+    az = fit_analyzer(ratios, n_states=3)
+    T = az.histograms.shape[0]
+    # The cycle is 9-periodic (3 frames major, 3 minor, 3 harm7).
+    # Pick anchors from different regimes within the same cycle:
+    t1, t2 = 1, 7    # major-frame -> harm7-frame
+    n_steps = 12
+    H_w = az.get_histograms(source="wasserstein_interp",
+                             t1=t1, t2=t2, n_steps=n_steps)
+    H_l = az.get_histograms(source="latent_interp",
+                             t1=t1, t2=t2, n_steps=n_steps)
+
+    fig, axes = plt.subplots(2, 1, figsize=(10.5, 5.2),
+                              gridspec_kw={"hspace": 0.45})
+    for ax, H, title in [
+        (axes[0], H_w, "(a) Wasserstein-quantile interpolation"),
+        (axes[1], H_l, "(b) Latent (PCA) interpolation"),
+    ]:
+        im = ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                        extent=[0, n_steps, 0, 1200])
+        ax.set_ylabel("cents")
+        ax.set_xlabel(f"interpolation step  ({t1} -> {t2})")
+        ax.set_title(title)
+        fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+
+    fig.suptitle("Figure 14 — Application: morphing between two recorded "
+                  "harmonic states  (two methods, same endpoints)",
+                  fontsize=12, y=0.98)
+    fig.savefig(OUT / "14_application_morphing.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 14_application_morphing.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+for fn in [
+    fig_scenarios_overview,
+    fig_dmd_oscillation,
+    fig_topology_scenarios,
+    fig_application_event_detection,
+    fig_application_fingerprinting,
+    fig_application_similarity,
+    fig_application_morphing,
+]:
+    fn()
+
+print("\nAll advanced figures generated into", OUT)

--- a/scripts/generate_harmonic_sequence_classical_apps.py
+++ b/scripts/generate_harmonic_sequence_classical_apps.py
@@ -1,0 +1,928 @@
+"""
+generate_harmonic_sequence_classical_apps.py
+============================================
+For each of the six approaches in harmonic_sequence, implement one
+"classical application" inspired by the canonical use of the underlying
+mathematical tool in another field, then adapt it to biotuner:
+
+  22. HarmonicMarkov  ->  Algorithmic composition from EEG
+        (Hiller-Isaacson n-state composition + render bridge)
+  23. Wasserstein     ->  Inter-group OT geodesic
+        (Schiebinger-style developmental trajectory between two
+         aggregate condition distributions)
+  24. HarmonicDMD     ->  Short-term harmonic forecasting
+        (Schmid/Brunton style train-then-forecast, with held-out RMSE)
+  25. LatentSpace     ->  Word-embedding-style group separation
+        (shared PCA + inter-group direction vector)
+  26. Topology        ->  Chaotic vs structured regime detection
+        (Takens fingerprint vs shuffle control, cardiac-arrhythmia style)
+  27. Grammar         ->  Stylometric authorship attribution
+        (n-gram log-likelihood classifier across conditions,
+         Mosteller-Wallace style)
+
+All six experiments reuse caches from the previous scripts:
+  - _real_eeg_bt_cache.npz       (Part IV, 60-channel EEG, ratios only)
+  - _tier1_A_cache.npz           (Part V.A, 234 sliding windows)
+  - _tier1_B_cache.npz           (Part V.B, 15 aud + 15 vis MNE epochs)
+
+Run:
+    python scripts/generate_harmonic_sequence_classical_apps.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.patches import Ellipse
+from matplotlib.lines import Line2D
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from biotuner.harmonic_sequence import (
+    HarmonicSequenceAnalyzer,
+    histograms_to_midi,
+    histogram_to_ratios,
+)
+
+CACHE_DIR = ROOT / "docs" / "papers"
+OUT = ROOT / "docs" / "papers" / "figures"
+MIDI_OUT = ROOT / "docs" / "papers" / "audio"
+OUT.mkdir(parents=True, exist_ok=True)
+MIDI_OUT.mkdir(parents=True, exist_ok=True)
+
+plt.rcParams.update({
+    "figure.dpi": 110, "savefig.dpi": 140, "font.size": 9,
+    "axes.spines.top": False, "axes.spines.right": False,
+})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cache loaders
+# ─────────────────────────────────────────────────────────────────────────────
+
+def load_partIV():
+    npz = np.load(CACHE_DIR / "_real_eeg_bt_cache.npz", allow_pickle=True)
+    return list(npz["ratios_list"])
+
+
+def load_A():
+    npz = np.load(CACHE_DIR / "_tier1_A_cache.npz", allow_pickle=True)
+    return (list(npz["ratios_list"]),
+            list(npz["peaks_list"]),
+            list(npz["metrics_list"]))
+
+
+def load_B():
+    npz = np.load(CACHE_DIR / "_tier1_B_cache.npz", allow_pickle=True)
+    return (list(npz["ratios_aud"]),
+            list(npz["ratios_vis"]),
+            list(npz["metrics_aud"]),
+            list(npz["metrics_vis"]))
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# App 22 — Markov: algorithmic composition from EEG
+# ═════════════════════════════════════════════════════════════════════════════
+
+def app_markov_composition():
+    print("\n[22] Markov: algorithmic composition from EEG (Hiller-Isaacson style)",
+          flush=True)
+    ratios_list = load_partIV()
+    az = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list, n_hist_bins=240)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        az.fit_markov(n_states="auto", auto_k_range=(2, 6))
+        az.fit_wasserstein()
+
+    K = az.markov.n_states
+    print(f"    K={K}, H_trans={az.markov.transition_entropy_:.2f} bits")
+
+    # Sample a 48-step chord sequence from the trained model
+    rng = np.random.default_rng(7)
+    T_sample = 48
+    sampled = az.get_histograms(source="markov_sample", n_steps=T_sample)
+    observed = az.histograms
+
+    # Render the sampled trajectory as MIDI
+    midi_path = MIDI_OUT / "22_markov_composition"
+    try:
+        cwd = os.getcwd()
+        os.chdir(MIDI_OUT)
+        try:
+            histograms_to_midi(
+                sampled, filename="22_markov_composition",
+                base_freq=220.0, duration_beats=0.4, n_peaks=4,
+                microtonal=True, velocity=72,
+            )
+            wrote = (MIDI_OUT / "22_markov_composition.mid").exists()
+        finally:
+            os.chdir(cwd)
+    except Exception as exc:
+        print(f"    MIDI render failed: {exc}")
+        wrote = False
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 9))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.2, 1.2, 1.0],
+                           hspace=0.55, wspace=0.30,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    # (a) Observed histogram trajectory
+    ax = fig.add_subplot(gs[0, :])
+    vmax = float(np.percentile(observed.ravel(), 99))
+    im = ax.imshow(observed.T, aspect="auto", origin="lower", cmap="magma",
+                    vmin=0, vmax=max(vmax, 1e-3),
+                    extent=[0, observed.shape[0], 0, 1200])
+    ax.set_xlabel("channel (training data)"); ax.set_ylabel("cents")
+    ax.set_title("(a) Observed harmonic trajectory  "
+                  f"(T={observed.shape[0]} channels) — input to Markov fit")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+
+    # (b) Sampled trajectory
+    ax = fig.add_subplot(gs[1, :])
+    im = ax.imshow(sampled.T, aspect="auto", origin="lower", cmap="magma",
+                    vmin=0, vmax=max(vmax, 1e-3),
+                    extent=[0, T_sample, 0, 1200])
+    ax.set_xlabel("composition step"); ax.set_ylabel("cents")
+    midi_note = (" — exported to " + str(midi_path.name) + ".mid" if wrote
+                 else "")
+    ax.set_title(f"(b) Algorithmically composed trajectory "
+                  f"(Markov-sample of length {T_sample})" + midi_note)
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+
+    # (c) State usage histograms (observed vs sampled)
+    ax = fig.add_subplot(gs[2, 0])
+    obs_lab = az.markov.state_labels_
+    smp_lab = np.array([
+        int(np.argmin(np.linalg.norm(
+            az.markov._km.cluster_centers_ - row, axis=1)))
+        for row in sampled
+    ])
+    obs_counts = np.bincount(obs_lab, minlength=K) / max(len(obs_lab), 1)
+    smp_counts = np.bincount(smp_lab, minlength=K) / max(len(smp_lab), 1)
+    x = np.arange(K)
+    width = 0.4
+    ax.bar(x - width/2, obs_counts, width, color="#4C72B0", label="observed")
+    ax.bar(x + width/2, smp_counts, width, color="#DD8452", label="sampled")
+    ax.set_xticks(x); ax.set_xticklabels([f"S{i}" for i in range(K)])
+    ax.set_ylabel("fraction of frames")
+    ax.set_title("(c) State usage: observed vs composed")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (d) Transition matrix heatmap
+    ax = fig.add_subplot(gs[2, 1])
+    T_mat = az.markov.transition_matrix_
+    im = ax.imshow(T_mat, cmap="rocket_r", vmin=0, vmax=1)
+    for i in range(K):
+        for j in range(K):
+            ax.text(j, i, f"{T_mat[i, j]:.2f}", ha="center", va="center",
+                     fontsize=7,
+                     color="white" if T_mat[i, j] > 0.5 else "black")
+    ax.set_xticks(range(K)); ax.set_yticks(range(K))
+    ax.set_xticklabels([f"S{i}" for i in range(K)])
+    ax.set_yticklabels([f"S{i}" for i in range(K)])
+    ax.set_title(f"(d) Learned transition matrix\n"
+                  f"H={az.markov.transition_entropy_:.2f} bits")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # (e) Cluster centroids as cents-histogram lines
+    ax = fig.add_subplot(gs[2, 2])
+    bin_cents = np.linspace(2.5, 1197.5, 240)
+    cmap_st = plt.get_cmap("tab10")
+    for i, c in enumerate(az.markov._km.cluster_centers_):
+        ax.plot(bin_cents, c + 0.025 * i, lw=1.0,
+                 color=cmap_st(i % 10), label=f"S{i}")
+    ax.set_xlabel("cents"); ax.set_ylabel("weight (offset)")
+    ax.set_title("(e) Cluster centroids = prototype tunings")
+    ax.legend(frameon=False, fontsize=7, ncol=2)
+
+    fig.suptitle(
+        "Figure 22 — Classical application: algorithmic composition "
+        "from EEG (Hiller-Isaacson 1957, adapted)",
+        fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "22_app_markov_composition.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 22_app_markov_composition.png "
+          f"(MIDI={'yes' if wrote else 'no'})")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# App 23 — Wasserstein: inter-group OT geodesic
+# ═════════════════════════════════════════════════════════════════════════════
+
+def app_wasserstein_geodesic():
+    print("\n[23] Wasserstein: inter-group OT geodesic between aud and vis",
+          flush=True)
+    ratios_aud, ratios_vis, _, _ = load_B()
+    az_aud = HarmonicSequenceAnalyzer.from_ratios_list(ratios_aud,
+                                                       n_hist_bins=240)
+    az_vis = HarmonicSequenceAnalyzer.from_ratios_list(ratios_vis,
+                                                       n_hist_bins=240)
+    H_aud = az_aud.histograms.mean(axis=0)
+    H_vis = az_vis.histograms.mean(axis=0)
+    # Normalise (mean of normalised hist is renormalised)
+    H_aud = H_aud / max(H_aud.sum(), 1e-9)
+    H_vis = H_vis / max(H_vis.sum(), 1e-9)
+
+    # OT-geodesic between H_aud and H_vis via quantile-space interpolation
+    from biotuner.harmonic_sequence import WassersteinTrajectory
+    wt = WassersteinTrajectory(n_bins=240)
+    alphas = np.linspace(0, 1, 9)
+    geodesic = np.stack([wt.barycenter(H_aud, H_vis, a) for a in alphas])
+    print(f"    geodesic shape: {geodesic.shape}, "
+          f"steps {alphas[0]:.2f} -> {alphas[-1]:.2f}")
+
+    # Render geodesic as MIDI (the brain-state morph audio)
+    try:
+        cwd = os.getcwd()
+        os.chdir(MIDI_OUT)
+        try:
+            histograms_to_midi(
+                geodesic, filename="23_wasserstein_geodesic",
+                base_freq=220.0, duration_beats=0.8, n_peaks=4,
+                microtonal=True, velocity=72,
+            )
+            wrote = (MIDI_OUT / "23_wasserstein_geodesic.mid").exists()
+        finally:
+            os.chdir(cwd)
+    except Exception as exc:
+        print(f"    MIDI render failed: {exc}")
+        wrote = False
+
+    # W1 distance between centroids
+    from scipy.stats import wasserstein_distance
+    bins = np.arange(240, dtype=float)
+    W_aud_vis = wasserstein_distance(bins, bins, H_aud, H_vis)
+    print(f"    W1(aud_mean, vis_mean) = {W_aud_vis:.2f} cents-bin units")
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 8))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.0, 1.5, 1.2],
+                           hspace=0.55, wspace=0.30,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    bin_cents = np.linspace(2.5, 1197.5, 240)
+
+    # (a) Two group means
+    ax = fig.add_subplot(gs[0, :])
+    ax.plot(bin_cents, H_aud, color="#4C72B0", lw=1.4,
+             label="auditory mean")
+    ax.plot(bin_cents, H_vis, color="#DD8452", lw=1.4,
+             label="visual mean")
+    ax.fill_between(bin_cents, 0, H_aud, color="#4C72B0", alpha=0.15)
+    ax.fill_between(bin_cents, 0, H_vis, color="#DD8452", alpha=0.15)
+    ax.set_xlabel("cents"); ax.set_ylabel("normalised weight")
+    ax.set_title(f"(a) Group-mean cents histograms  "
+                  f"($W_1 = {W_aud_vis:.2f}$ between them)")
+    ax.legend(frameon=False, fontsize=9)
+
+    # (b) Geodesic as a heatmap (interp step on x, cents on y)
+    ax = fig.add_subplot(gs[1, :])
+    vmax = float(np.percentile(geodesic.ravel(), 99))
+    im = ax.imshow(geodesic.T, aspect="auto", origin="lower", cmap="magma",
+                    vmin=0, vmax=max(vmax, 1e-3),
+                    extent=[0, len(alphas) - 1, 0, 1200])
+    ax.set_xlabel(r"interpolation step  ($\alpha=0$: aud  $\to$  $\alpha=1$: vis)")
+    ax.set_ylabel("cents")
+    midi_note = (" -> exported as " + "23_wasserstein_geodesic.mid"
+                 if wrote else "")
+    ax.set_title(f"(b) $W_1$-geodesic between the two group distributions"
+                  + midi_note)
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01, label="weight")
+    for i in range(1, len(alphas) - 1):
+        ax.axvline(i, color="white", lw=0.3, alpha=0.4)
+
+    # (c) Three slices: aud, midpoint, vis
+    ax = fig.add_subplot(gs[2, 0])
+    ax.plot(bin_cents, geodesic[0], color="#4C72B0", lw=1.3,
+             label=r"$\alpha=0$ (aud)")
+    ax.plot(bin_cents, geodesic[len(alphas) // 2],
+             color="#888", lw=1.3, label=r"$\alpha=0.5$ (midpoint)")
+    ax.plot(bin_cents, geodesic[-1], color="#DD8452", lw=1.3,
+             label=r"$\alpha=1$ (vis)")
+    ax.set_xlabel("cents"); ax.set_ylabel("weight")
+    ax.set_title("(c) Three geodesic slices")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (d) Per-step W1 distance from aud / from vis
+    ax = fig.add_subplot(gs[2, 1])
+    d_from_aud = [wasserstein_distance(bins, bins, g, H_aud)
+                  for g in geodesic]
+    d_from_vis = [wasserstein_distance(bins, bins, g, H_vis)
+                  for g in geodesic]
+    ax.plot(alphas, d_from_aud, "o-", color="#4C72B0", label="W1 to aud")
+    ax.plot(alphas, d_from_vis, "s-", color="#DD8452", label="W1 to vis")
+    ax.set_xlabel(r"$\alpha$"); ax.set_ylabel("W1")
+    ax.set_title("(d) Linear interpolation in W1 distance")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (e) Decoded ratios at each step (text)
+    ax = fig.add_subplot(gs[2, 2])
+    ax.axis("off")
+    text_rows = []
+    for i, a in enumerate(alphas):
+        r = histogram_to_ratios(geodesic[i], n_peaks=3,
+                                include_unison=False, include_octave=False)
+        rstr = ", ".join(f"{x:.3f}" for x in r) if r else "—"
+        text_rows.append(f"α={a:.2f}: {rstr}")
+    ax.text(0.0, 1.0, "\n".join(text_rows), fontsize=8.5,
+             family="monospace", va="top")
+    ax.set_title("(e) Top-3 ratios at each geodesic step", fontsize=10)
+
+    fig.suptitle("Figure 23 — Classical application: inter-group OT "
+                  "geodesic (developmental-trajectory style)",
+                  fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "23_app_wasserstein_geodesic.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 23_app_wasserstein_geodesic.png "
+          f"(MIDI={'yes' if wrote else 'no'})")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# App 24 — DMD: short-term harmonic forecasting
+# ═════════════════════════════════════════════════════════════════════════════
+
+def app_dmd_forecasting():
+    print("\n[24] DMD: short-term harmonic forecasting on Tier 1 A (234 windows)",
+          flush=True)
+    ratios_list, _, _ = load_A()
+    n_total = len(ratios_list)
+    n_train = int(0.8 * n_total)
+    n_test = n_total - n_train
+    print(f"    train: {n_train}, test: {n_test}")
+
+    # Fit cents histograms then PCA-reduce, then DMD on PCA
+    az_train = HarmonicSequenceAnalyzer.from_ratios_list(
+        ratios_list[:n_train], n_hist_bins=240,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        az_train.fit_dmd(use_histograms=True)
+        az_train.fit_latent(latent_dim=5)
+
+    # PCA basis from train, project both train and test histograms
+    from sklearn.decomposition import PCA
+    H_full = HarmonicSequenceAnalyzer.from_ratios_list(
+        ratios_list, n_hist_bins=240,
+    ).histograms
+    pca = PCA(n_components=10).fit(H_full[:n_train])
+    Z_train = pca.transform(H_full[:n_train])
+    Z_test = pca.transform(H_full[n_train:])
+
+    # DMD on Z_train, forecast n_test steps from end of train
+    from biotuner.harmonic_sequence import HarmonicDMD
+    dmd = HarmonicDMD(rank=8, center=True).fit(Z_train)
+    Z_pred = dmd.reconstruct(n_steps=n_test)
+    print(f"    Z_pred shape {Z_pred.shape}, Z_test shape {Z_test.shape}")
+
+    # RMSE per PC + global RMSE
+    err = Z_test - Z_pred
+    rmse_per_pc = np.sqrt(np.mean(err ** 2, axis=0))
+    rmse_global = float(np.sqrt(np.mean(err ** 2)))
+    # Compare to naive last-value forecast
+    naive = np.tile(Z_train[-1], (n_test, 1))
+    rmse_naive = float(np.sqrt(np.mean((Z_test - naive) ** 2)))
+    # And to a "mean-of-train" forecast
+    rmse_mean = float(np.sqrt(np.mean(
+        (Z_test - Z_train.mean(axis=0)) ** 2)))
+    print(f"    RMSE: DMD={rmse_global:.4f}  naive_last={rmse_naive:.4f}  "
+          f"naive_mean={rmse_mean:.4f}")
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 8.5))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.2, 1.2, 1.0],
+                           hspace=0.55, wspace=0.30,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    # (a) PC1 actual vs forecast over time
+    ax = fig.add_subplot(gs[0, :])
+    ax.plot(np.arange(n_train), Z_train[:, 0],
+             color="black", lw=1.0, label="train")
+    ax.plot(np.arange(n_train, n_total), Z_test[:, 0],
+             color="#4C72B0", lw=1.4, label="test (actual)")
+    ax.plot(np.arange(n_train, n_total), Z_pred[:, 0],
+             color="crimson", lw=1.4, ls="--", label="DMD forecast")
+    ax.axvline(n_train - 0.5, color="grey", lw=0.6, ls=":")
+    ax.set_xlabel("window"); ax.set_ylabel("PC1 coordinate")
+    ax.set_title("(a) PC1 trajectory: train -> forecast vs actual")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (b) PC2
+    ax = fig.add_subplot(gs[1, :])
+    ax.plot(np.arange(n_train), Z_train[:, 1],
+             color="black", lw=1.0, label="train")
+    ax.plot(np.arange(n_train, n_total), Z_test[:, 1],
+             color="#4C72B0", lw=1.4, label="test")
+    ax.plot(np.arange(n_train, n_total), Z_pred[:, 1],
+             color="crimson", lw=1.4, ls="--", label="DMD forecast")
+    ax.axvline(n_train - 0.5, color="grey", lw=0.6, ls=":")
+    ax.set_xlabel("window"); ax.set_ylabel("PC2 coordinate")
+    ax.set_title("(b) PC2 trajectory")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (c) RMSE bar chart
+    ax = fig.add_subplot(gs[2, 0])
+    names = ["DMD", "naive\nlast-value", "naive\ntrain-mean"]
+    vals = [rmse_global, rmse_naive, rmse_mean]
+    colors = ["crimson", "#888", "#444"]
+    bars = ax.bar(names, vals, color=colors)
+    for b, v in zip(bars, vals):
+        ax.text(b.get_x() + b.get_width()/2, v + 0.005 * max(vals),
+                 f"{v:.3f}", ha="center", fontsize=8)
+    ax.set_ylabel("RMSE")
+    ax.set_title("(c) Held-out forecast RMSE")
+
+    # (d) Per-PC RMSE
+    ax = fig.add_subplot(gs[2, 1])
+    ax.bar(np.arange(len(rmse_per_pc)) + 1, rmse_per_pc, color="#4C72B0")
+    ax.set_xlabel("PC index"); ax.set_ylabel("per-PC RMSE")
+    ax.set_title("(d) Forecast error per PC dim")
+
+    # (e) DMD eigenvalues
+    ax = fig.add_subplot(gs[2, 2])
+    theta = np.linspace(0, 2 * np.pi, 200)
+    ax.plot(np.cos(theta), np.sin(theta), color="grey", lw=0.7, ls="--")
+    eigs = dmd.eigenvalues_
+    ax.scatter(eigs.real, eigs.imag, s=60, color="crimson", alpha=0.8)
+    ax.set_xlim(-1.3, 1.3); ax.set_ylim(-1.3, 1.3); ax.set_aspect("equal")
+    ax.axhline(0, color="grey", lw=0.3); ax.axvline(0, color="grey", lw=0.3)
+    ax.set_xlabel(r"Re($\lambda$)"); ax.set_ylabel(r"Im($\lambda$)")
+    ax.set_title(f"(e) DMD spectrum (rank={len(eigs)})")
+
+    fig.suptitle("Figure 24 — Classical application: short-term DMD "
+                  "forecasting (Schmid-Brunton style)",
+                  fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "24_app_dmd_forecasting.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 24_app_dmd_forecasting.png")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# App 25 — Latent: word-embedding-style group separation
+# ═════════════════════════════════════════════════════════════════════════════
+
+def app_latent_embedding():
+    print("\n[25] Latent: shared PCA + inter-group direction (aud vs vis)",
+          flush=True)
+    ratios_aud, ratios_vis, _, _ = load_B()
+    az_aud = HarmonicSequenceAnalyzer.from_ratios_list(ratios_aud,
+                                                       n_hist_bins=240)
+    az_vis = HarmonicSequenceAnalyzer.from_ratios_list(ratios_vis,
+                                                       n_hist_bins=240)
+    H_aud = az_aud.histograms
+    H_vis = az_vis.histograms
+
+    # Joint PCA on combined histograms
+    from sklearn.decomposition import PCA
+    H_all = np.vstack([H_aud, H_vis])
+    labels = np.array([0] * len(H_aud) + [1] * len(H_vis))
+    pca = PCA(n_components=3).fit(H_all - H_all.mean(axis=0))
+    Z = pca.transform(H_all - H_all.mean(axis=0))
+    Z_aud = Z[labels == 0]
+    Z_vis = Z[labels == 1]
+    centroid_aud = Z_aud.mean(axis=0)
+    centroid_vis = Z_vis.mean(axis=0)
+    direction = centroid_vis - centroid_aud
+    direction_norm = float(np.linalg.norm(direction))
+    print(f"    inter-group direction norm: {direction_norm:.3f}")
+    print(f"    explained var: {pca.explained_variance_ratio_.round(3)}")
+
+    # Quick group-separability metric: silhouette score with the labels
+    from sklearn.metrics import silhouette_score
+    try:
+        sil = silhouette_score(Z, labels)
+    except Exception:
+        sil = float("nan")
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 8))
+    gs = fig.add_gridspec(2, 3, hspace=0.45, wspace=0.30,
+                           left=0.06, right=0.97, top=0.92, bottom=0.07)
+
+    # (a) Joint PC1-PC2 scatter with ellipses
+    def _ellipse(points, ax, **kwargs):
+        if len(points) < 2: return
+        cov = np.cov(points.T)
+        eigvals, eigvecs = np.linalg.eigh(cov)
+        order = eigvals.argsort()[::-1]
+        eigvals, eigvecs = eigvals[order], eigvecs[:, order]
+        angle = np.degrees(np.arctan2(eigvecs[1, 0], eigvecs[0, 0]))
+        # 2-sigma ellipse for visualisation
+        w, h = 2 * 2 * np.sqrt(np.maximum(eigvals, 0))
+        e = Ellipse(xy=points.mean(axis=0), width=w, height=h, angle=angle,
+                     **kwargs)
+        ax.add_patch(e)
+
+    ax = fig.add_subplot(gs[0, 0])
+    ax.scatter(Z_aud[:, 0], Z_aud[:, 1], s=42, color="#4C72B0",
+                edgecolor="white", lw=0.6, label="auditory")
+    ax.scatter(Z_vis[:, 0], Z_vis[:, 1], s=42, color="#DD8452",
+                edgecolor="white", lw=0.6, label="visual")
+    _ellipse(Z_aud[:, :2], ax, ec="#4C72B0", fc="none", lw=1.2, alpha=0.7)
+    _ellipse(Z_vis[:, :2], ax, ec="#DD8452", fc="none", lw=1.2, alpha=0.7)
+    ax.scatter(*centroid_aud[:2], s=160, marker="X", color="#4C72B0",
+                edgecolor="black", lw=1.0, zorder=5)
+    ax.scatter(*centroid_vis[:2], s=160, marker="X", color="#DD8452",
+                edgecolor="black", lw=1.0, zorder=5)
+    ax.annotate("", xy=centroid_vis[:2], xytext=centroid_aud[:2],
+                 arrowprops=dict(arrowstyle="->", color="black", lw=1.4))
+    ax.set_xlabel("PC1"); ax.set_ylabel("PC2")
+    ax.set_title(f"(a) Joint embedding  (silhouette={sil:.2f})")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (b) PC1 vs PC3
+    ax = fig.add_subplot(gs[0, 1])
+    ax.scatter(Z_aud[:, 0], Z_aud[:, 2], s=42, color="#4C72B0",
+                edgecolor="white", lw=0.6, label="auditory")
+    ax.scatter(Z_vis[:, 0], Z_vis[:, 2], s=42, color="#DD8452",
+                edgecolor="white", lw=0.6, label="visual")
+    ax.scatter(*[centroid_aud[0], centroid_aud[2]], s=160, marker="X",
+                color="#4C72B0", edgecolor="black", lw=1.0, zorder=5)
+    ax.scatter(*[centroid_vis[0], centroid_vis[2]], s=160, marker="X",
+                color="#DD8452", edgecolor="black", lw=1.0, zorder=5)
+    ax.set_xlabel("PC1"); ax.set_ylabel("PC3")
+    ax.set_title("(b) PC1 vs PC3")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (c) Inter-group direction on the cents axis (the "aud-to-vis vector")
+    ax = fig.add_subplot(gs[0, 2])
+    # Project direction back to histogram space via inverse PCA
+    delta_hist = pca.inverse_transform(direction[np.newaxis, :])[0]
+    bin_cents = np.linspace(2.5, 1197.5, 240)
+    ax.plot(bin_cents, delta_hist, color="black", lw=1.2)
+    ax.axhline(0, color="grey", lw=0.4)
+    ax.fill_between(bin_cents, 0, delta_hist,
+                     where=delta_hist > 0, color="#DD8452", alpha=0.4,
+                     label="visual+ direction")
+    ax.fill_between(bin_cents, 0, delta_hist,
+                     where=delta_hist <= 0, color="#4C72B0", alpha=0.4,
+                     label="auditory+ direction")
+    ax.set_xlabel("cents"); ax.set_ylabel("aud->vis loading")
+    ax.set_title("(c) Inter-group direction on cents axis")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (d) Per-PC group means with error bars
+    ax = fig.add_subplot(gs[1, 0])
+    pcs = np.arange(3)
+    width = 0.36
+    aud_mean = Z_aud.mean(axis=0); aud_std = Z_aud.std(axis=0)
+    vis_mean = Z_vis.mean(axis=0); vis_std = Z_vis.std(axis=0)
+    ax.bar(pcs - width/2, aud_mean, width, yerr=aud_std, capsize=4,
+            color="#4C72B0", label="auditory", alpha=0.85)
+    ax.bar(pcs + width/2, vis_mean, width, yerr=vis_std, capsize=4,
+            color="#DD8452", label="visual", alpha=0.85)
+    ax.set_xticks(pcs); ax.set_xticklabels(["PC1", "PC2", "PC3"])
+    ax.set_ylabel("coordinate (mean ± std)")
+    ax.set_title("(d) Per-PC group means")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (e) Linear classifier accuracy
+    ax = fig.add_subplot(gs[1, 1])
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.model_selection import cross_val_score
+    accs = []
+    for n_pc in range(1, 4):
+        scores = cross_val_score(
+            LogisticRegression(max_iter=400),
+            Z[:, :n_pc], labels, cv=5)
+        accs.append(scores.mean())
+    ax.plot([1, 2, 3], accs, "o-", color="black", lw=1.4)
+    ax.axhline(0.5, color="grey", lw=0.5, ls="--", label="chance")
+    ax.set_xticks([1, 2, 3])
+    ax.set_xlabel("PCs used"); ax.set_ylabel("5-fold CV accuracy")
+    ax.set_title("(e) Logistic-regression classifier accuracy")
+    ax.set_ylim(0.3, 1.05)
+    ax.legend(frameon=False, fontsize=8)
+
+    # (f) Explained variance
+    ax = fig.add_subplot(gs[1, 2])
+    ax.bar(np.arange(3) + 1, pca.explained_variance_ratio_,
+            color="#4C72B0")
+    ax.set_xlabel("PC"); ax.set_ylabel("explained variance")
+    ax.set_title(f"(f) Joint-PCA scree  "
+                  f"({pca.explained_variance_ratio_.sum():.1%} cumul)")
+
+    fig.suptitle("Figure 25 — Classical application: word-embedding-style "
+                  "group separation in shared latent space",
+                  fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "25_app_latent_embedding.png", bbox_inches="tight")
+    plt.close(fig)
+    print(f"    saved 25_app_latent_embedding.png  (silhouette={sil:.2f}, "
+          f"CV-acc(3PC)={accs[-1]:.2f})")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# App 26 — Topology: chaotic vs structured via shuffle control
+# ═════════════════════════════════════════════════════════════════════════════
+
+def app_topology_chaos():
+    print("\n[26] Topology: chaotic vs structured (shuffle-control test)",
+          flush=True)
+    _, _, metrics_list = load_A()
+    hs = np.array([float(m.get("harmsim", np.nan)) for m in metrics_list],
+                  dtype=float)
+    hs = hs[np.isfinite(hs)]
+    print(f"    harmsim time series length: {len(hs)}")
+
+    rng = np.random.default_rng(0)
+    hs_shuffled = hs.copy(); rng.shuffle(hs_shuffled)
+
+    # Takens embed + persistent homology on both
+    from biotuner.harmonic_sequence import HarmonicTopology
+    top_real = HarmonicTopology(embedding_dim=3, delay=2).fit(hs)
+    top_rand = HarmonicTopology(embedding_dim=3, delay=2).fit(hs_shuffled)
+    fp_real = top_real.session_fingerprint()
+    fp_rand = top_rand.session_fingerprint()
+    print(f"    real fingerprint:    {fp_real.round(3).tolist()}")
+    print(f"    shuffled fingerprint:{fp_rand.round(3).tolist()}")
+
+    # Multiple shuffles for null distribution
+    n_shuffles = 30
+    fps_null = []
+    for s in range(n_shuffles):
+        sh = hs.copy(); rng.shuffle(sh)
+        try:
+            fps_null.append(
+                HarmonicTopology(embedding_dim=3, delay=2).fit(sh)
+                                                          .session_fingerprint())
+        except Exception:
+            pass
+    fps_null = np.array(fps_null)
+    print(f"    {len(fps_null)} successful shuffles")
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 9))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.0, 1.2, 1.0],
+                           hspace=0.55, wspace=0.35,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    # (a) Scalar time series (real)
+    ax = fig.add_subplot(gs[0, :])
+    ax.plot(hs, color="#4C72B0", lw=1.0, label="real harmsim")
+    ax.plot(hs_shuffled, color="#DD8452", lw=0.6, alpha=0.5,
+             label="shuffled")
+    ax.set_xlabel("window"); ax.set_ylabel("harmsim")
+    ax.set_title("(a) Scalar harmonicity time series — real signal "
+                  "and one shuffled control")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (b) Takens cloud REAL
+    ax = fig.add_subplot(gs[1, 0])
+    cloud_r = top_real.takens_embedding_
+    ax.scatter(cloud_r[:, 0], cloud_r[:, 1],
+                c=np.arange(len(cloud_r)), cmap="viridis", s=20,
+                edgecolor="white", lw=0.4)
+    ax.plot(cloud_r[:, 0], cloud_r[:, 1], color="grey", lw=0.3, alpha=0.4)
+    ax.set_title("(b) Takens cloud — REAL")
+    ax.set_xlabel("x(t)"); ax.set_ylabel(r"x(t+$\tau$)")
+
+    # (c) Takens cloud SHUFFLED
+    ax = fig.add_subplot(gs[1, 1])
+    cloud_s = top_rand.takens_embedding_
+    ax.scatter(cloud_s[:, 0], cloud_s[:, 1],
+                c=np.arange(len(cloud_s)), cmap="plasma", s=20,
+                edgecolor="white", lw=0.4)
+    ax.set_title("(c) Takens cloud — SHUFFLED")
+    ax.set_xlabel("x(t)"); ax.set_ylabel(r"x(t+$\tau$)")
+
+    # (d) Persistence diagrams overlaid
+    ax = fig.add_subplot(gs[1, 2])
+    for top, name, color in [(top_real, "real", "#4C72B0"),
+                              (top_rand, "shuffled", "#DD8452")]:
+        diagrams = top.persistence_diagram_
+        for dim, dgm in enumerate(diagrams[:1]):
+            finite = dgm[np.isfinite(dgm[:, 1])]
+            if len(finite):
+                ax.scatter(finite[:, 0], finite[:, 1], s=24, alpha=0.6,
+                            color=color, label=f"{name} H{dim}")
+    lim = max(ax.get_xlim()[1], ax.get_ylim()[1], 1)
+    ax.plot([0, lim], [0, lim], color="grey", lw=0.4, ls="--")
+    ax.set_xlim(0, lim); ax.set_ylim(0, lim)
+    ax.set_xlabel("birth"); ax.set_ylabel("death")
+    ax.set_title("(d) Persistence diagrams")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (e) Fingerprint comparison with null distribution
+    metric_names = ["mean_H0_pers", "max_H0_pers", "n_H0_bars",
+                    "mean_H1_pers", "max_H1_pers", "n_H1_bars"]
+    ax = fig.add_subplot(gs[2, :])
+    if len(fps_null):
+        bp = ax.boxplot(fps_null, positions=np.arange(len(metric_names)),
+                         widths=0.55, patch_artist=True,
+                         boxprops=dict(facecolor="#DD8452", alpha=0.4),
+                         medianprops=dict(color="black"))
+    ax.scatter(np.arange(len(metric_names)), fp_real,
+                s=120, marker="*", color="crimson", zorder=5,
+                label="real fingerprint")
+    ax.scatter(np.arange(len(metric_names)),
+                fps_null.mean(axis=0) if len(fps_null) else [],
+                s=60, marker="o", color="black", zorder=4,
+                label=f"shuffle-mean (n={len(fps_null)})")
+    ax.set_xticks(np.arange(len(metric_names)))
+    ax.set_xticklabels(metric_names, rotation=20, ha="right", fontsize=8)
+    ax.set_ylabel("value")
+    ax.set_title("(e) Real fingerprint vs shuffle null distribution — "
+                  "where the star sits outside the box, structure is "
+                  "stronger than chance")
+    ax.legend(frameon=False, fontsize=8)
+
+    fig.suptitle("Figure 26 — Classical application: topological chaos "
+                  "vs structure (cardiac-arrhythmia style)",
+                  fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "26_app_topology_chaos.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 26_app_topology_chaos.png")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# App 27 — Grammar: stylometric condition attribution
+# ═════════════════════════════════════════════════════════════════════════════
+
+def app_grammar_stylometry():
+    print("\n[27] Grammar: n-gram stylometry classifying aud vs vis epochs",
+          flush=True)
+    ratios_aud, ratios_vis, _, _ = load_B()
+    # Build chord sequences via the grammar's labelling
+    from biotuner.harmonic_sequence import HarmonicGrammar, _chord_label
+    n = len(ratios_aud)
+    seqs_aud = [_chord_label(r, tolerance_cents=30.0) for r in ratios_aud]
+    seqs_vis = [_chord_label(r, tolerance_cents=30.0) for r in ratios_vis]
+    # Each epoch is currently a single chord (a frozenset). For an n-gram
+    # to be meaningful we group N adjacent epochs into one "phrase".
+    PHRASE_LEN = 3
+    def _phrases(seqs):
+        phrases = []
+        for i in range(0, len(seqs) - PHRASE_LEN + 1):
+            phrases.append(tuple(seqs[i:i+PHRASE_LEN]))
+        return phrases
+    phr_aud = _phrases(seqs_aud)
+    phr_vis = _phrases(seqs_vis)
+    print(f"    aud phrases: {len(phr_aud)}  vis phrases: {len(phr_vis)}")
+
+    # Build bigram models per condition via collections.Counter
+    from collections import Counter
+    def _bigram_model(phrases):
+        counts = Counter()
+        contexts = Counter()
+        for phrase in phrases:
+            for i in range(len(phrase) - 1):
+                counts[(phrase[i], phrase[i + 1])] += 1
+                contexts[(phrase[i],)] += 1
+        return counts, contexts
+
+    counts_aud, ctx_aud = _bigram_model(phr_aud)
+    counts_vis, ctx_vis = _bigram_model(phr_vis)
+    print(f"    aud bigrams: {len(counts_aud)}  vis bigrams: {len(counts_vis)}")
+
+    # Score a phrase under a model: sum log P(token_{i+1} | token_i)
+    # with Laplace smoothing
+    VOCAB = set(
+        [t for phrase in (phr_aud + phr_vis) for t in phrase] +
+        list(set([t for c in (counts_aud, counts_vis) for t in [k[1] for k in c]]))
+    )
+    V = max(1, len(VOCAB))
+
+    def _logp_phrase(phrase, counts, contexts):
+        # P(t_{i+1}|t_i) = (count + 1) / (ctx + V)
+        s = 0.0
+        for i in range(len(phrase) - 1):
+            c = counts.get((phrase[i], phrase[i+1]), 0)
+            n = contexts.get((phrase[i],), 0)
+            s += np.log((c + 1.0) / (n + V))
+        return s
+
+    # Test: leave-one-phrase-out cross-validation
+    all_phrases = phr_aud + phr_vis
+    labels = np.array([0] * len(phr_aud) + [1] * len(phr_vis))
+    n_phrases = len(all_phrases)
+
+    preds = []
+    for i in range(n_phrases):
+        # Remove phrase i from training, rebuild bigram counts
+        train_phr_aud = [p for j, p in enumerate(phr_aud) if j != i]
+        train_phr_vis = [p for j, p in enumerate(phr_vis)
+                          if (j + len(phr_aud)) != i]
+        c_a, x_a = _bigram_model(train_phr_aud)
+        c_v, x_v = _bigram_model(train_phr_vis)
+        lp_a = _logp_phrase(all_phrases[i], c_a, x_a)
+        lp_v = _logp_phrase(all_phrases[i], c_v, x_v)
+        preds.append(0 if lp_a > lp_v else 1)
+    preds = np.array(preds)
+    acc = float((preds == labels).mean())
+    from sklearn.metrics import confusion_matrix
+    cm = confusion_matrix(labels, preds, labels=[0, 1])
+    print(f"    LOO accuracy: {acc:.2f}, confusion:\n{cm}")
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 8))
+    gs = fig.add_gridspec(2, 3, hspace=0.50, wspace=0.30,
+                           left=0.06, right=0.97, top=0.92, bottom=0.07)
+
+    # (a) Chord-token streams (aud and vis side by side, coloured)
+    ax = fig.add_subplot(gs[0, :])
+    all_tokens = list({t for seqs in (seqs_aud, seqs_vis) for t in seqs})
+    tok_id = {t: i for i, t in enumerate(all_tokens)}
+    cmap = plt.get_cmap("tab20")
+    for i, t in enumerate(seqs_aud):
+        ax.add_patch(plt.Rectangle((i, 0), 1, 0.4,
+                                    color=cmap(tok_id[t] % 20)))
+    for i, t in enumerate(seqs_vis):
+        ax.add_patch(plt.Rectangle((i + len(seqs_aud) + 2, 0), 1, 0.4,
+                                    color=cmap(tok_id[t] % 20)))
+    ax.set_xlim(0, len(seqs_aud) + len(seqs_vis) + 2)
+    ax.set_ylim(-0.05, 0.55)
+    ax.set_yticks([])
+    ax.set_xlabel("epoch")
+    ax.text(len(seqs_aud) / 2, 0.46, "AUDITORY", ha="center",
+             fontsize=9, color="#4C72B0", fontweight="bold")
+    ax.text(len(seqs_aud) + 2 + len(seqs_vis) / 2, 0.46, "VISUAL",
+             ha="center", fontsize=9, color="#DD8452", fontweight="bold")
+    ax.set_title(f"(a) Per-epoch chord tokens  "
+                  f"(vocab={len(all_tokens)} distinct chords)")
+
+    # (b) Confusion matrix
+    ax = fig.add_subplot(gs[1, 0])
+    im = ax.imshow(cm, cmap="rocket_r", vmin=0)
+    for i in range(2):
+        for j in range(2):
+            ax.text(j, i, str(cm[i, j]), ha="center", va="center",
+                     fontsize=14, color="white" if cm[i, j] > cm.max()*0.5
+                     else "black")
+    ax.set_xticks([0, 1]); ax.set_xticklabels(["aud", "vis"])
+    ax.set_yticks([0, 1]); ax.set_yticklabels(["aud", "vis"])
+    ax.set_xlabel("predicted"); ax.set_ylabel("true")
+    ax.set_title(f"(b) LOO confusion matrix\n"
+                  f"accuracy = {acc:.2f}  (chance = 0.5)")
+
+    # (c) Per-phrase log-likelihood difference distribution
+    ax = fig.add_subplot(gs[1, 1])
+    diffs = []
+    for i in range(n_phrases):
+        lp_a = _logp_phrase(all_phrases[i], counts_aud, ctx_aud)
+        lp_v = _logp_phrase(all_phrases[i], counts_vis, ctx_vis)
+        diffs.append(lp_a - lp_v)
+    diffs = np.array(diffs)
+    ax.hist(diffs[labels == 0], bins=12, color="#4C72B0", alpha=0.6,
+             label=f"true aud (n={(labels==0).sum()})")
+    ax.hist(diffs[labels == 1], bins=12, color="#DD8452", alpha=0.6,
+             label=f"true vis (n={(labels==1).sum()})")
+    ax.axvline(0, color="black", lw=0.8, ls="--", label="decision = 0")
+    ax.set_xlabel(r"$\log P(\mathrm{phrase}|\mathrm{aud}) - \log P(\mathrm{phrase}|\mathrm{vis})$",
+                  fontsize=8)
+    ax.set_ylabel("count")
+    ax.set_title("(c) Per-phrase classifier score")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (d) Vocabulary venn-ish: per-token frequency aud vs vis
+    ax = fig.add_subplot(gs[1, 2])
+    cnt_aud = Counter(seqs_aud); cnt_vis = Counter(seqs_vis)
+    keys = sorted(set(cnt_aud) | set(cnt_vis), key=lambda k: -cnt_aud.get(k, 0) - cnt_vis.get(k, 0))[:12]
+    a_freq = [cnt_aud.get(k, 0) / max(len(seqs_aud), 1) for k in keys]
+    v_freq = [cnt_vis.get(k, 0) / max(len(seqs_vis), 1) for k in keys]
+    x = np.arange(len(keys))
+    width = 0.4
+    ax.bar(x - width/2, a_freq, width, color="#4C72B0", label="aud")
+    ax.bar(x + width/2, v_freq, width, color="#DD8452", label="vis")
+    ax.set_xticks(x)
+    ax.set_xticklabels([f"C{i}" for i in range(len(keys))], fontsize=8)
+    ax.set_ylabel("token frequency")
+    ax.set_title(f"(d) Top-12 chord-token frequencies\n"
+                  f"(vocab_aud={len(cnt_aud)}, vocab_vis={len(cnt_vis)})")
+    ax.legend(frameon=False, fontsize=8)
+
+    fig.suptitle("Figure 27 — Classical application: stylometric "
+                  "condition attribution (Mosteller-Wallace style)",
+                  fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "27_app_grammar_stylometry.png", bbox_inches="tight")
+    plt.close(fig)
+    print(f"    saved 27_app_grammar_stylometry.png  (LOO acc={acc:.2f})")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    apps = [
+        app_markov_composition,
+        app_wasserstein_geodesic,
+        app_dmd_forecasting,
+        app_latent_embedding,
+        app_topology_chaos,
+        app_grammar_stylometry,
+    ]
+    for fn in apps:
+        try:
+            fn()
+        except Exception as exc:
+            import traceback
+            print(f"    !! {fn.__name__} failed: {exc}")
+            traceback.print_exc()
+    print(f"\nAll classical-application figures in {OUT}")

--- a/scripts/generate_harmonic_sequence_paper_figures.py
+++ b/scripts/generate_harmonic_sequence_paper_figures.py
@@ -1,0 +1,430 @@
+"""
+generate_harmonic_sequence_paper_figures.py
+===========================================
+Produce the figures used in the ``harmonic_sequence`` use-case paper.
+
+Builds a controlled 36-frame ratio sequence cycling through three harmonic
+regimes (just-major, just-minor, harmonic-7) with intra-regime drift, then
+plots one or two illustrative figures per approach into
+``docs/papers/figures/``.
+
+Run:
+    python scripts/generate_harmonic_sequence_paper_figures.py
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.patches import Circle
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from biotuner.harmonic_sequence import (
+    HarmonicSequenceAnalyzer,
+    encode_histograms,
+    histogram_to_ratios,
+)
+
+OUT = ROOT / "docs" / "papers" / "figures"
+OUT.mkdir(parents=True, exist_ok=True)
+
+plt.rcParams.update({
+    "figure.dpi": 110,
+    "savefig.dpi": 140,
+    "font.size": 9,
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+})
+
+# Three harmonic regimes
+JUST_MAJOR = [1.0, 9 / 8, 5 / 4, 4 / 3, 3 / 2, 5 / 3, 15 / 8]
+JUST_MINOR = [1.0, 9 / 8, 6 / 5, 4 / 3, 3 / 2, 8 / 5, 9 / 5]
+HARM_7 = [1.0, 9 / 8, 5 / 4, 11 / 8, 3 / 2, 7 / 4, 15 / 8]
+REGIMES = [JUST_MAJOR, JUST_MINOR, HARM_7]
+REGIME_NAMES = ["major", "minor", "harm7"]
+REGIME_COLOURS = ["#4C72B0", "#DD8452", "#55A868"]
+
+
+def build_sequence(n_cycles: int = 4, frames_per_regime: int = 3, seed: int = 0):
+    """Build T = n_cycles * 3 * frames_per_regime alternating ratio sequence."""
+    rng = np.random.default_rng(seed)
+    ratios_list = []
+    regime_index = []
+    # Two scales of variation:
+    #   - tiny intra-regime drift (~0.5 cents, keeps grammar tokens stable)
+    #   - regime-coherent micro-variation (~1.5 cents on every k>0 frame)
+    for c in range(n_cycles):
+        for r_idx, base in enumerate(REGIMES):
+            for k in range(frames_per_regime):
+                jitter = 1.0 + 0.0003 * rng.standard_normal(len(base))
+                ratios_list.append([float(x * j) for x, j in zip(base, jitter)])
+                regime_index.append(r_idx)
+    return ratios_list, np.array(regime_index)
+
+
+# ---------------------------------------------------------------------------
+# Build the shared analyzer
+# ---------------------------------------------------------------------------
+print(f"Output directory: {OUT}")
+ratios_list, regime_idx = build_sequence(n_cycles=4, frames_per_regime=3)
+T = len(ratios_list)
+print(f"Sequence length T = {T} frames over {T // 9} cycles of 3 regimes")
+
+analyzer = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list, n_hist_bins=240)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    analyzer.fit_all(n_states=3, latent_dim=3, n_gram=2,
+                     topology_scalar="harmsim")
+print(analyzer.summary())
+
+H = analyzer.histograms                # (T, 240)
+
+
+# ---------------------------------------------------------------------------
+# Fig 0  — Pipeline schematic + the raw histogram-trajectory heatmap
+# ---------------------------------------------------------------------------
+def fig_overview():
+    fig, ax = plt.subplots(figsize=(8.5, 2.4))
+    im = ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                   extent=[0, T, 0, 1200])
+    ax.set_xlabel("Frame (window index)")
+    ax.set_ylabel("Cents (0 = unison, 1200 = octave)")
+    ax.set_title("Encoded cents histogram across time  —  the input every model consumes")
+    # Mark regime boundaries with thin lines
+    for t in range(1, T):
+        if regime_idx[t] != regime_idx[t - 1]:
+            ax.axvline(t, color="white", lw=0.4, alpha=0.5)
+    cbar = fig.colorbar(im, ax=ax, pad=0.01)
+    cbar.set_label("histogram weight")
+    fig.tight_layout()
+    fig.savefig(OUT / "00_input_histograms.png")
+    plt.close(fig)
+    print("  saved 00_input_histograms.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 1  — Markov: transition matrix + state timeline
+# ---------------------------------------------------------------------------
+def fig_markov():
+    mk = analyzer.markov
+    K = mk.n_states
+    fig, axes = plt.subplots(1, 2, figsize=(9.5, 3.4),
+                              gridspec_kw={"width_ratios": [1.2, 2.2]})
+
+    # (a) transition matrix heatmap
+    ax = axes[0]
+    im = ax.imshow(mk.transition_matrix_, cmap="rocket_r", vmin=0, vmax=1)
+    for i in range(K):
+        for j in range(K):
+            ax.text(j, i, f"{mk.transition_matrix_[i, j]:.2f}",
+                     ha="center", va="center", fontsize=8,
+                     color="white" if mk.transition_matrix_[i, j] > 0.5 else "black")
+    ax.set_xticks(range(K)); ax.set_yticks(range(K))
+    ax.set_xlabel("next state"); ax.set_ylabel("current state")
+    ax.set_title(f"(a) Transition matrix  (K={K})")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # (b) state timeline (top = Markov labels, bottom = ground-truth regime)
+    ax = axes[1]
+    cmap_states = plt.get_cmap("tab10")
+    for t in range(T):
+        ax.add_patch(plt.Rectangle((t, 0.55), 1, 0.4,
+                                    color=cmap_states(mk.state_labels_[t] % 10)))
+        ax.add_patch(plt.Rectangle((t, 0.05), 1, 0.4,
+                                    color=REGIME_COLOURS[regime_idx[t]]))
+    ax.set_xlim(0, T); ax.set_ylim(0, 1)
+    ax.set_yticks([0.25, 0.75]); ax.set_yticklabels(["regime (ground truth)",
+                                                       "Markov state"])
+    ax.set_xlabel("Frame")
+    ax.set_title("(b) Discovered state timeline vs ground-truth regime")
+    ax.set_xticks(np.arange(0, T + 1, 9))
+    # Legend strip for regimes
+    for i, name in enumerate(REGIME_NAMES):
+        ax.scatter([], [], color=REGIME_COLOURS[i], s=60, label=name)
+    ax.legend(loc="upper right", bbox_to_anchor=(1.0, -0.18), ncol=3,
+              frameon=False, fontsize=8)
+
+    fig.suptitle("Approach 1 — HarmonicMarkov", fontsize=11, y=1.02)
+    fig.tight_layout()
+    fig.savefig(OUT / "01_markov.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 01_markov.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 2  — Wasserstein: distance matrix + flux + MDS embedding
+# ---------------------------------------------------------------------------
+def fig_wasserstein():
+    wt = analyzer.wasserstein
+    D = wt.distance_matrix_
+    flux = wt.flux_
+
+    fig, axes = plt.subplots(1, 3, figsize=(11, 3.4))
+
+    # (a) pairwise W1 distance
+    ax = axes[0]
+    im = ax.imshow(D, cmap="viridis")
+    ax.set_xlabel("frame j"); ax.set_ylabel("frame i")
+    ax.set_title("(a) Pairwise $W_1$ distance")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # (b) flux over time
+    ax = axes[1]
+    ax.plot(np.arange(len(flux)), flux, color="black", lw=1.4)
+    # Shade regime boundaries
+    for t in range(1, T):
+        if regime_idx[t] != regime_idx[t - 1]:
+            ax.axvline(t - 0.5, color="crimson", alpha=0.5, lw=0.8, ls="--")
+    ax.set_xlabel("Frame transition (t → t+1)")
+    ax.set_ylabel("$W_1(h_t, h_{t+1})$  (cents-units)")
+    ax.set_title("(b) Harmonic flux  (dashes = regime change)")
+
+    # (c) MDS embedding
+    ax = axes[2]
+    Z = wt.embed(n_components=2, method="mds")
+    for r_idx, name in enumerate(REGIME_NAMES):
+        mask = regime_idx == r_idx
+        ax.scatter(Z[mask, 0], Z[mask, 1], color=REGIME_COLOURS[r_idx],
+                    s=42, alpha=0.8, label=name, edgecolor="white", lw=0.8)
+    # Connect consecutive frames with thin lines
+    ax.plot(Z[:, 0], Z[:, 1], color="grey", lw=0.4, alpha=0.5, zorder=0)
+    ax.set_xlabel("MDS-1"); ax.set_ylabel("MDS-2")
+    ax.set_title("(c) MDS embedding")
+    ax.legend(frameon=False, fontsize=8, loc="best")
+
+    fig.suptitle("Approach 2 — WassersteinTrajectory", fontsize=11, y=1.02)
+    fig.tight_layout()
+    fig.savefig(OUT / "02_wasserstein.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 02_wasserstein.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 3  — DMD: eigenvalues on complex plane + reconstruction
+# ---------------------------------------------------------------------------
+def fig_dmd():
+    # Rebuild analyzer with DMD on histogram-PCA so we have meaningful spectrum
+    a2 = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list, n_hist_bins=240)
+    a2.fit_dmd(use_histograms=True)
+    dmd = a2.dmd
+    eigs = dmd.eigenvalues_
+
+    fig, axes = plt.subplots(1, 2, figsize=(9.5, 3.6))
+
+    # (a) eigenvalues on the complex plane
+    ax = axes[0]
+    theta = np.linspace(0, 2 * np.pi, 200)
+    ax.plot(np.cos(theta), np.sin(theta), color="grey", lw=0.8, ls="--")
+    ax.add_patch(Circle((0, 0), 1, fill=False, color="grey", lw=0.8))
+    ax.axhline(0, color="grey", lw=0.4); ax.axvline(0, color="grey", lw=0.4)
+    osc, idx = dmd.oscillatory_modes(threshold=0.1)
+    is_osc = np.zeros(len(eigs), dtype=bool); is_osc[idx] = True
+    ax.scatter(eigs[~is_osc].real, eigs[~is_osc].imag,
+                s=70, color="#888", alpha=0.8, label="decaying")
+    ax.scatter(eigs[is_osc].real, eigs[is_osc].imag,
+                s=110, color="crimson", marker="*", label="oscillatory")
+    ax.set_xlim(-1.4, 1.4); ax.set_ylim(-1.4, 1.4)
+    ax.set_aspect("equal")
+    ax.set_xlabel(r"Re($\lambda$)"); ax.set_ylabel(r"Im($\lambda$)")
+    ax.set_title("(a) DMD eigenvalues  (unit circle = pure oscillation)")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (b) growth-rate vs frequency
+    ax = axes[1]
+    ax.scatter(dmd.frequencies_, dmd.growth_rates_,
+                s=70, c=np.abs(eigs), cmap="plasma")
+    ax.axhline(0, color="grey", lw=0.5, ls="--")
+    ax.set_xlabel("frequency  Im[log $\\lambda$]")
+    ax.set_ylabel("growth rate  Re[log $\\lambda$]")
+    ax.set_title("(b) Growth vs. oscillation frequency per mode")
+
+    fig.suptitle("Approach 3 — HarmonicDMD", fontsize=11, y=1.02)
+    fig.tight_layout()
+    fig.savefig(OUT / "03_dmd.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 03_dmd.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 4  — Latent: trajectory in 3D PCA space + scree
+# ---------------------------------------------------------------------------
+def fig_latent():
+    ls = analyzer.latent
+    Z = ls.trajectory()
+    evr = ls.explained_variance_ratio_
+
+    fig = plt.figure(figsize=(10.5, 3.6))
+    ax1 = fig.add_subplot(1, 2, 1, projection="3d")
+    for r_idx, name in enumerate(REGIME_NAMES):
+        mask = regime_idx == r_idx
+        ax1.scatter(Z[mask, 0], Z[mask, 1], Z[mask, 2],
+                     color=REGIME_COLOURS[r_idx], s=42, alpha=0.9, label=name,
+                     edgecolor="white", lw=0.6)
+    ax1.plot(Z[:, 0], Z[:, 1], Z[:, 2], color="grey", lw=0.5, alpha=0.4)
+    ax1.set_xlabel("PC1"); ax1.set_ylabel("PC2"); ax1.set_zlabel("PC3")
+    ax1.set_title("(a) Trajectory in 3-D latent space")
+    ax1.legend(frameon=False, fontsize=8)
+
+    ax2 = fig.add_subplot(1, 2, 2)
+    cum = np.cumsum(evr)
+    ax2.bar(np.arange(1, len(evr) + 1), evr, color="#4C72B0", alpha=0.7,
+             label="per-dim")
+    ax2.plot(np.arange(1, len(evr) + 1), cum, "o-", color="crimson",
+              label="cumulative")
+    ax2.set_xlabel("latent dim"); ax2.set_ylabel("explained variance")
+    ax2.set_title(f"(b) Scree  (3 dims explain {cum[-1]:.1%})")
+    ax2.legend(frameon=False, fontsize=8)
+    ax2.set_xticks(np.arange(1, len(evr) + 1))
+
+    fig.suptitle("Approach 4 — HarmonicLatentSpace", fontsize=11, y=1.02)
+    fig.tight_layout()
+    fig.savefig(OUT / "04_latent.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 04_latent.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 5  — Topology: Takens embedding + persistence diagram
+# ---------------------------------------------------------------------------
+def fig_topology():
+    top = analyzer.topology
+    cloud = top.takens_embedding_     # (N, d=3)
+
+    fig, axes = plt.subplots(1, 2, figsize=(9.5, 3.6))
+
+    # (a) Takens cloud — colour by frame number
+    ax = axes[0]
+    sc = ax.scatter(cloud[:, 0], cloud[:, 1],
+                     c=np.arange(len(cloud)), cmap="viridis", s=44,
+                     edgecolor="white", lw=0.6)
+    ax.plot(cloud[:, 0], cloud[:, 1], color="grey", lw=0.4, alpha=0.4)
+    ax.set_xlabel("x(t)"); ax.set_ylabel(rf"x(t+{top.delay})")
+    ax.set_title(f"(a) Takens delay-embedding  (d={top.embedding_dim}, "
+                  rf"$\tau={top.delay}$)")
+    fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.04, label="frame")
+
+    # (b) persistence diagram
+    ax = axes[1]
+    diagrams = top.persistence_diagram_
+    max_finite = 0.0
+    for dim, dgm in enumerate(diagrams):
+        finite = dgm[np.isfinite(dgm[:, 1])]
+        if len(finite):
+            max_finite = max(max_finite, finite[:, 1].max())
+            label = f"H{dim}"
+            ax.scatter(finite[:, 0], finite[:, 1], s=40,
+                        label=label, alpha=0.8)
+    lims = [0, max_finite * 1.1 if max_finite > 0 else 1]
+    ax.plot(lims, lims, color="grey", lw=0.6, ls="--")
+    ax.set_xlim(lims); ax.set_ylim(lims)
+    ax.set_xlabel("birth"); ax.set_ylabel("death")
+    title = "(b) Persistence diagram"
+    if len(diagrams) == 1:
+        title += "  (H0 only — install ripser for H1)"
+    ax.set_title(title)
+    ax.legend(frameon=False, fontsize=8)
+
+    fig.suptitle("Approach 5 — HarmonicTopology  (TDA)", fontsize=11, y=1.02)
+    fig.tight_layout()
+    fig.savefig(OUT / "05_topology.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 05_topology.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 6  — Grammar: token sequence + top motifs
+# ---------------------------------------------------------------------------
+def fig_grammar():
+    gr = analyzer.grammar
+    seq = gr.chord_sequence_
+    vocab = gr.vocabulary_
+    chord_to_id = {c: i for i, c in enumerate(vocab)}
+    ids = np.array([chord_to_id[c] for c in seq])
+
+    fig, axes = plt.subplots(1, 2, figsize=(11, 3.6),
+                              gridspec_kw={"width_ratios": [2, 1]})
+
+    # (a) chord-token stream as stem plot
+    ax = axes[0]
+    cmap_tok = plt.get_cmap("tab20")
+    for t, tok in enumerate(ids):
+        ax.add_patch(plt.Rectangle((t, tok - 0.4), 1, 0.8,
+                                    color=cmap_tok(tok % 20)))
+    ax.set_xlim(0, len(ids)); ax.set_ylim(-1, len(vocab))
+    ax.set_xlabel("Frame")
+    ax.set_ylabel("Chord-token id")
+    ax.set_yticks(np.arange(len(vocab)))
+    short = []
+    for c in vocab:
+        if len(c) == 0:
+            short.append("∅")
+        else:
+            # Shorten frozenset labels for axis ticks
+            names = sorted(c, key=len)[:1]
+            label = next(iter(c))
+            short.append((label[:18] + "…") if len(label) > 18 else label)
+    ax.set_yticklabels(short, fontsize=7)
+    ax.set_title(f"(a) Symbolic chord stream  (vocab={len(vocab)})")
+
+    # (b) top motifs as bar chart
+    ax = axes[1]
+    motifs = gr.top_motifs(min_length=2, max_length=3, top_k=8)
+    if motifs:
+        labels = [f"len{len(m)}: " + "→".join(str(chord_to_id[t]) for t in m)
+                  for m, _ in motifs]
+        counts = [c for _, c in motifs]
+        ax.barh(range(len(labels)), counts, color="#4C72B0")
+        ax.set_yticks(range(len(labels)))
+        ax.set_yticklabels(labels, fontsize=7)
+        ax.invert_yaxis()
+        ax.set_xlabel("count")
+        ax.set_title("(b) Top motifs (chord-id sequences)")
+    else:
+        ax.text(0.5, 0.5, "no motifs", ha="center", va="center")
+
+    fig.suptitle(f"Approach 6 — HarmonicGrammar  "
+                  f"(H_trans = {gr.transition_entropy_:.2f} bits)",
+                  fontsize=11, y=1.02)
+    fig.tight_layout()
+    fig.savefig(OUT / "06_grammar.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 06_grammar.png")
+
+
+# ---------------------------------------------------------------------------
+# Fig 7  — Render bridge: Wasserstein-interpolated glissando
+# ---------------------------------------------------------------------------
+def fig_bridge():
+    n = 10
+    glide = analyzer.get_histograms(source="wasserstein_interp",
+                                     t1=0, t2=15, n_steps=n)
+    fig, ax = plt.subplots(figsize=(9, 3.0))
+    im = ax.imshow(glide.T, aspect="auto", origin="lower", cmap="magma",
+                    extent=[0, n, 0, 1200])
+    ax.set_xlabel("interpolation step  (0 → major frame, 9 → minor frame)")
+    ax.set_ylabel("cents")
+    ax.set_title("Render bridge — Wasserstein glissando between two frames")
+    fig.colorbar(im, ax=ax, label="weight", pad=0.01)
+    fig.tight_layout()
+    fig.savefig(OUT / "07_bridge_glissando.png")
+    plt.close(fig)
+    print("  saved 07_bridge_glissando.png")
+
+
+# ---------------------------------------------------------------------------
+# Run all
+# ---------------------------------------------------------------------------
+for fn in [fig_overview, fig_markov, fig_wasserstein, fig_dmd,
+           fig_latent, fig_topology, fig_grammar, fig_bridge]:
+    fn()
+
+print("\nAll figures generated.")

--- a/scripts/generate_harmonic_sequence_real_data.py
+++ b/scripts/generate_harmonic_sequence_real_data.py
@@ -1,0 +1,485 @@
+"""
+generate_harmonic_sequence_real_data.py
+=======================================
+Run the harmonic_sequence pipeline on real EEG data from the repo's example
+file (`docs/examples/data/EEG_example.npy`, 104 channels x 4 s @ 1 kHz) and
+produce three figures for the use-case paper:
+
+  15_real_eeg_overview.png      Channels-as-sequence + the four lenses.
+  16_real_eeg_method_compare.png Six methods on the SAME real recording.
+  17_real_eeg_app_retrieval.png  Application — k-nearest-neighbour channel
+                                 retrieval via the W1 distance matrix.
+
+The EEG file is multi-channel, single-trial (no time axis longer than 4 s).
+We treat channels as a *spatial sequence*: each channel is one "frame" in
+the analyser. This is a perfectly valid input for the module — it learns
+the harmonic structure across channels, which on a head montage corresponds
+to a walk across cortical regions. Spatial Markov / Wasserstein / TDA still
+have intuitive interpretations (spatial states, between-channel harmonic
+flux, cortical attractor count). For genuine temporal analysis, replace the
+bt_list construction with a sliding-window loop on a long single-channel
+recording.
+
+Run:
+    python scripts/generate_harmonic_sequence_real_data.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from biotuner.biotuner_object import compute_biotuner
+from biotuner.harmonic_sequence import HarmonicSequenceAnalyzer
+
+OUT = ROOT / "docs" / "papers" / "figures"
+OUT.mkdir(parents=True, exist_ok=True)
+
+plt.rcParams.update({
+    "figure.dpi": 110, "savefig.dpi": 140, "font.size": 9,
+    "axes.spines.top": False, "axes.spines.right": False,
+})
+
+DATA_PATH = ROOT / "docs" / "examples" / "data" / "EEG_example.npy"
+SF = 1000
+FREQ_BANDS = [[1, 3], [3, 7], [7, 12], [12, 18], [18, 30], [30, 45]]
+N_CHANNELS = 60          # subset to keep runtime reasonable (~60 s)
+CHANNEL_START = 20       # skip noisier leading edge channels
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Load + build bt_list (channels as frames)
+# ─────────────────────────────────────────────────────────────────────────────
+
+print(f"Loading {DATA_PATH.name}...")
+data = np.load(DATA_PATH)
+print(f"  data shape: {data.shape}  (channels x samples)  sf = {SF} Hz")
+
+channels = list(range(CHANNEL_START, CHANNEL_START + N_CHANNELS))
+print(f"  using {N_CHANNELS} channels (indices {channels[0]}..{channels[-1]})")
+
+# Cache file so the slow peaks_extraction step only runs once.
+CACHE_PATH = ROOT / "docs" / "papers" / "_real_eeg_bt_cache.npz"
+if CACHE_PATH.exists():
+    print(f"  loading cached bt_list ratios from {CACHE_PATH.name}")
+    npz = np.load(CACHE_PATH, allow_pickle=True)
+    ratios_list = list(npz["ratios_list"])
+    peaks_list = list(npz["peaks_list"])
+    harmsim_list = npz["harmsim_list"].tolist()
+else:
+    print("  running peaks_extraction on each channel...")
+    t0 = time.time()
+    ratios_list = []
+    peaks_list = []
+    harmsim_list = []
+    for i, ch in enumerate(channels):
+        bt = compute_biotuner(sf=SF, peaks_function="fixed", precision=0.5,
+                              n_harm=10)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            try:
+                bt.peaks_extraction(data[ch].astype(np.float64),
+                                     FREQ_BANDS=FREQ_BANDS,
+                                     ratios_extension=True,
+                                     max_freq=45, n_peaks=5,
+                                     graph=False, min_harms=2, verbose=False)
+                bt.compute_peaks_metrics()
+            except Exception as exc:
+                print(f"    ch{ch}: peaks_extraction failed ({exc!s:.50})")
+                ratios_list.append([])
+                peaks_list.append([])
+                harmsim_list.append(np.nan)
+                continue
+        peaks = list(bt.peaks) if bt.peaks is not None else []
+        ratios = list(bt.peaks_ratios) if getattr(bt, "peaks_ratios",
+                                                    None) else []
+        pm = getattr(bt, "peaks_metrics", {}) or {}
+        try:
+            hs = float(pm.get("harmsim", np.nan))
+        except Exception:
+            hs = np.nan
+        ratios_list.append(ratios)
+        peaks_list.append(peaks)
+        harmsim_list.append(hs)
+        if (i + 1) % 10 == 0:
+            elapsed = time.time() - t0
+            print(f"    {i+1}/{N_CHANNELS} done  ({elapsed:.1f}s elapsed)")
+    print(f"  peaks_extraction finished in {time.time() - t0:.1f}s")
+    # Cache
+    np.savez(CACHE_PATH,
+             ratios_list=np.array(ratios_list, dtype=object),
+             peaks_list=np.array(peaks_list, dtype=object),
+             harmsim_list=np.array(harmsim_list))
+    print(f"  cached to {CACHE_PATH.name}")
+
+T = len(ratios_list)
+n_valid = sum(1 for r in ratios_list if len(r) > 0)
+print(f"  {n_valid}/{T} channels yielded non-empty ratio sets")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Build and fit analyzer
+# ─────────────────────────────────────────────────────────────────────────────
+
+analyzer = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list, n_hist_bins=240)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    # Drop frames with empty ratio sets so the model fits don't bias on them.
+    # (They remain in `analyzer.histograms` as zero rows; encoders cope.)
+    analyzer.fit_markov(n_states="auto", auto_k_range=(2, 6))
+    analyzer.fit_wasserstein()
+    analyzer.fit_latent(latent_dim=3)
+    try:
+        analyzer.fit_dmd(use_histograms=True)
+    except Exception as exc:
+        print(f"  DMD failed: {exc}")
+    try:
+        analyzer.fit_grammar(n_gram=2)
+    except Exception as exc:
+        print(f"  Grammar failed: {exc}")
+    try:
+        # Use the cached harmsim metric extracted during peaks_extraction
+        # (the analyzer recomputes from ratios when not provided).
+        analyzer.fit_topology(scalar_key="harmsim", embedding_dim=3, delay=1)
+    except Exception as exc:
+        print(f"  Topology failed: {exc}")
+
+print("\n" + analyzer.summary())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 15 — overview of the real EEG sequence through 4 lenses
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_overview():
+    H = analyzer.histograms
+    flux = analyzer.wasserstein.flux_
+    Z = analyzer.latent.trajectory()
+    labels = analyzer.markov.state_labels_
+    K = analyzer.markov.n_states
+    harmsim = np.array(harmsim_list)
+
+    fig = plt.figure(figsize=(14, 10))
+    gs = fig.add_gridspec(4, 3, height_ratios=[1.6, 1.0, 1.2, 1.2],
+                           hspace=0.55, wspace=0.30,
+                           left=0.07, right=0.98, top=0.94, bottom=0.07)
+
+    # (a) histogram heatmap with Markov state strip
+    ax = fig.add_subplot(gs[0, :])
+    im = ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                    extent=[0, T, 0, 1200])
+    ax.set_xlabel("channel (frame index)")
+    ax.set_ylabel("cents")
+    ax.set_title("(a) Cents-histogram trajectory across 60 EEG channels "
+                  f"(K={K} Markov states discovered)")
+    fig.colorbar(im, ax=ax, pad=0.01, fraction=0.025, label="weight")
+
+    # (b) harmsim per channel
+    ax = fig.add_subplot(gs[1, :])
+    ax.plot(np.arange(T), harmsim, color="black", lw=1.4)
+    finite_hs = harmsim[np.isfinite(harmsim)]
+    if len(finite_hs):
+        ax.axhline(np.nanmean(harmsim), color="grey", ls="--", lw=0.7,
+                    label=f"mean = {np.nanmean(harmsim):.2f}")
+    cmap_st = plt.get_cmap("tab10")
+    ymin = ax.get_ylim()[0]
+    strip_h = (ax.get_ylim()[1] - ymin) * 0.08
+    for t in range(T):
+        ax.add_patch(plt.Rectangle((t - 0.5, ymin - strip_h * 1.3),
+                                    1, strip_h,
+                                    color=cmap_st(int(labels[t]) % 10),
+                                    clip_on=False))
+    ax.set_xlim(0, T)
+    ax.set_ylim(ymin - strip_h * 1.5, ax.get_ylim()[1])
+    ax.set_ylabel("harmsim")
+    ax.set_xlabel("channel")
+    ax.set_title("(b) Per-channel harmonicity-similarity (from biotuner peaks_metrics)")
+    ax.legend(frameon=False, loc="upper right", fontsize=8)
+
+    # (c) W1 flux
+    ax = fig.add_subplot(gs[2, 0])
+    ax.plot(np.arange(len(flux)), flux, color="black", lw=1.3)
+    ax.set_xlabel("channel transition")
+    ax.set_ylabel("$W_1$ flux")
+    ax.set_title("(c) Between-channel harmonic flux")
+
+    # (d) pairwise distance matrix
+    ax = fig.add_subplot(gs[2, 1])
+    D = analyzer.wasserstein.distance_matrix_
+    im = ax.imshow(D, cmap="viridis")
+    ax.set_xlabel("channel j"); ax.set_ylabel("channel i")
+    ax.set_title("(d) Pairwise $W_1$ matrix")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # (e) latent PCA scatter coloured by harmsim
+    ax = fig.add_subplot(gs[2, 2])
+    sc = ax.scatter(Z[:, 0], Z[:, 1], c=harmsim, cmap="plasma",
+                     s=44, edgecolor="white", lw=0.6)
+    ax.plot(Z[:, 0], Z[:, 1], color="grey", lw=0.4, alpha=0.4)
+    ax.set_xlabel("PC1"); ax.set_ylabel("PC2")
+    evr = analyzer.latent.explained_variance_ratio_
+    ax.set_title(f"(e) PC1-PC2  ({evr[:2].sum():.0%} var)")
+    fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.04, label="harmsim")
+
+    # (f) DMD eigenvalues
+    ax = fig.add_subplot(gs[3, 0])
+    if analyzer.dmd is not None:
+        eigs = analyzer.dmd.eigenvalues_
+        theta = np.linspace(0, 2 * np.pi, 200)
+        ax.plot(np.cos(theta), np.sin(theta), color="grey", lw=0.6, ls="--")
+        osc, idx = analyzer.dmd.oscillatory_modes(threshold=0.1)
+        is_osc = np.zeros(len(eigs), dtype=bool); is_osc[idx] = True
+        ax.scatter(eigs[~is_osc].real, eigs[~is_osc].imag,
+                    s=50, color="#888", alpha=0.7, label="decaying")
+        ax.scatter(eigs[is_osc].real, eigs[is_osc].imag,
+                    s=120, color="crimson", marker="*",
+                    label=f"|λ|≈1 ({len(idx)})")
+        ax.set_xlim(-1.3, 1.3); ax.set_ylim(-1.3, 1.3); ax.set_aspect("equal")
+        ax.axhline(0, color="grey", lw=0.3); ax.axvline(0, color="grey", lw=0.3)
+        ax.set_xlabel(r"Re($\lambda$)"); ax.set_ylabel(r"Im($\lambda$)")
+        ax.legend(frameon=False, fontsize=7)
+        ax.set_title("(f) DMD spectrum")
+    else:
+        ax.text(0.5, 0.5, "DMD failed", ha="center", va="center")
+
+    # (g) Markov transition matrix
+    ax = fig.add_subplot(gs[3, 1])
+    T_mat = analyzer.markov.transition_matrix_
+    im = ax.imshow(T_mat, cmap="rocket_r", vmin=0, vmax=1)
+    K_ = T_mat.shape[0]
+    for i in range(K_):
+        for j in range(K_):
+            ax.text(j, i, f"{T_mat[i, j]:.2f}", ha="center", va="center",
+                     fontsize=7,
+                     color="white" if T_mat[i, j] > 0.5 else "black")
+    ax.set_xticks(range(K_)); ax.set_yticks(range(K_))
+    ax.set_xlabel("next"); ax.set_ylabel("current")
+    ax.set_title(f"(g) Transition matrix  (H = {analyzer.markov.transition_entropy_:.2f} bits)")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # (h) grammar top motifs
+    ax = fig.add_subplot(gs[3, 2])
+    if analyzer.grammar is not None:
+        motifs = analyzer.grammar.top_motifs(min_length=2, max_length=3,
+                                              top_k=6)
+        if motifs:
+            labels_m = []
+            counts = []
+            chord_to_id = {c: i for i, c
+                           in enumerate(analyzer.grammar.vocabulary_)}
+            for m, c in motifs:
+                labels_m.append("→".join(str(chord_to_id[t]) for t in m))
+                counts.append(c)
+            ax.barh(range(len(labels_m)), counts, color="#4C72B0")
+            ax.set_yticks(range(len(labels_m)))
+            ax.set_yticklabels(labels_m, fontsize=8)
+            ax.invert_yaxis()
+            ax.set_xlabel("count")
+            ax.set_title(f"(h) Top motifs  (vocab={len(analyzer.grammar.vocabulary_)})")
+        else:
+            ax.text(0.5, 0.5, "no motifs", ha="center", va="center")
+    else:
+        ax.text(0.5, 0.5, "Grammar failed", ha="center", va="center")
+
+    fig.suptitle(
+        f"Figure 15 — Real EEG ({DATA_PATH.name}, {N_CHANNELS} channels) "
+        "through the harmonic_sequence pipeline",
+        fontsize=12.5, y=0.985,
+    )
+    fig.savefig(OUT / "15_real_eeg_overview.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 15_real_eeg_overview.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 16 — same recording, six lenses (analogue of fig_method_comparison)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_six_lenses():
+    """Show what each fitted model represents internally on real EEG."""
+    fig = plt.figure(figsize=(15, 9))
+    gs = fig.add_gridspec(2, 3, hspace=0.50, wspace=0.30,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    # (1) Markov centroids — each is a prototype "harmonic mood" histogram
+    ax = fig.add_subplot(gs[0, 0])
+    centroids = analyzer.markov._km.cluster_centers_
+    bin_cents = np.linspace(2.5, 1197.5, centroids.shape[1])
+    for i, c in enumerate(centroids):
+        ax.plot(bin_cents, c + 0.04 * i, lw=1.1,
+                 label=f"state {i}", alpha=0.9)
+    ax.set_xlabel("cents"); ax.set_ylabel("histogram weight (offset)")
+    ax.set_title("(1) Markov: K-means centroids in cents space")
+    ax.legend(frameon=False, fontsize=7, loc="upper right")
+
+    # (2) PCA components on the cents axis
+    ax = fig.add_subplot(gs[0, 1])
+    pcs = analyzer.latent._pca.components_      # (latent_dim, n_bins)
+    for i in range(min(3, pcs.shape[0])):
+        ax.plot(bin_cents, pcs[i], lw=1.1,
+                 label=f"PC{i+1}  ({analyzer.latent.explained_variance_ratio_[i]:.1%})",
+                 alpha=0.85)
+    ax.axhline(0, color="grey", lw=0.4)
+    ax.set_xlabel("cents"); ax.set_ylabel("loading")
+    ax.set_title("(2) Latent: principal components in cents space")
+    ax.legend(frameon=False, fontsize=7)
+
+    # (3) Wasserstein barycenter morph between first and last channels
+    ax = fig.add_subplot(gs[0, 2])
+    wt = analyzer.wasserstein
+    n = 8
+    morph = np.stack(wt.interpolate_pair(0, T - 1, n_steps=n), axis=0)
+    im = ax.imshow(morph.T, aspect="auto", origin="lower", cmap="magma",
+                    extent=[0, n, 0, 1200])
+    ax.set_xlabel(f"interp step (channel 0 -> {T-1})")
+    ax.set_ylabel("cents")
+    ax.set_title("(3) Wasserstein: barycenter morph")
+    fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+    # (4) DMD top oscillatory modes magnitude (spatial loading)
+    ax = fig.add_subplot(gs[1, 0])
+    if analyzer.dmd is not None and analyzer.dmd.modes_ is not None:
+        modes = analyzer.dmd.modes_              # complex (D, r)
+        dist = np.abs(np.abs(analyzer.dmd.eigenvalues_) - 1.0)
+        top = np.argsort(dist)[:3]
+        for j, k in enumerate(top):
+            mag = np.abs(modes[:, k])
+            ax.plot(mag + 0.02 * j, lw=1.1,
+                     label=f"mode {k}  (|λ|={np.abs(analyzer.dmd.eigenvalues_[k]):.2f})")
+        ax.set_xlabel("PCA-component index")
+        ax.set_ylabel("|mode| (offset)")
+        ax.set_title("(4) DMD: top oscillatory modes")
+        ax.legend(frameon=False, fontsize=7)
+
+    # (5) Takens cloud for the harmsim trajectory
+    ax = fig.add_subplot(gs[1, 1])
+    if analyzer.topology is not None:
+        cloud = analyzer.topology.takens_embedding_
+        sc = ax.scatter(cloud[:, 0], cloud[:, 1],
+                         c=np.arange(len(cloud)), cmap="viridis",
+                         s=44, edgecolor="white", lw=0.6)
+        ax.plot(cloud[:, 0], cloud[:, 1], color="grey", lw=0.4, alpha=0.4)
+        beta = analyzer.topology.betti_numbers_
+        ax.set_xlabel("x(t)"); ax.set_ylabel("x(t+1)")
+        ax.set_title(f"(5) Topology: Takens cloud  (β0={beta[0]})")
+        fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.04, label="channel")
+
+    # (6) Grammar vocabulary as a chord-stream
+    ax = fig.add_subplot(gs[1, 2])
+    if analyzer.grammar is not None:
+        chord_to_id = {c: i for i, c
+                       in enumerate(analyzer.grammar.vocabulary_)}
+        ids = np.array([chord_to_id[c]
+                         for c in analyzer.grammar.chord_sequence_])
+        cmap_g = plt.get_cmap("tab20")
+        for t, tok in enumerate(ids):
+            ax.add_patch(plt.Rectangle((t, tok - 0.4), 1, 0.8,
+                                        color=cmap_g(int(tok) % 20)))
+        ax.set_xlim(0, len(ids))
+        ax.set_ylim(-1, len(analyzer.grammar.vocabulary_))
+        ax.set_xlabel("channel")
+        ax.set_ylabel("chord-token id")
+        ax.set_title(f"(6) Grammar: chord stream  "
+                      f"(vocab={len(analyzer.grammar.vocabulary_)}, "
+                      f"H={analyzer.grammar.transition_entropy_:.2f} bits)")
+
+    fig.suptitle(
+        "Figure 16 — What each of the six models learned on the same real EEG",
+        fontsize=12.5, y=0.985,
+    )
+    fig.savefig(OUT / "16_real_eeg_method_compare.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 16_real_eeg_method_compare.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Figure 17 — Application: harmonically-similar channel retrieval
+# ─────────────────────────────────────────────────────────────────────────────
+
+def fig_retrieval():
+    """Pick a query channel, retrieve the k nearest harmonic neighbours via
+    the W1 distance matrix, and visualise the result."""
+    D = analyzer.wasserstein.distance_matrix_
+    harmsim = np.array(harmsim_list)
+
+    # Choose a query channel: one with high harmsim (most "consonant"
+    # channel — usually striking on an EEG resting recording).
+    finite_idx = np.where(np.isfinite(harmsim))[0]
+    if len(finite_idx) == 0:
+        print("  fig_retrieval: no finite harmsim — skipping")
+        return
+    q = int(finite_idx[np.argmax(harmsim[finite_idx])])
+    # k-nearest harmonic neighbours (excluding self)
+    k = 5
+    order = np.argsort(D[q])
+    nearest = [j for j in order if j != q][:k]
+    farthest = [j for j in order[::-1] if j != q][:k]
+
+    fig = plt.figure(figsize=(14, 7.2))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.0, 1.4, 1.4],
+                           hspace=0.55, wspace=0.30,
+                           left=0.06, right=0.98, top=0.92, bottom=0.08)
+
+    # Top: W1 row for the query, highlighting nearest/farthest
+    ax = fig.add_subplot(gs[0, :])
+    ax.bar(np.arange(T), D[q], color="#888", alpha=0.65)
+    ax.bar(nearest, D[q][nearest], color="seagreen", label=f"{k} nearest")
+    ax.bar(farthest, D[q][farthest], color="crimson", label=f"{k} farthest")
+    ax.axvline(q, color="black", lw=1.0, ls="--",
+                label=f"query channel {channels[q]}  (harmsim={harmsim[q]:.2f})")
+    ax.set_xlabel("channel"); ax.set_ylabel(f"$W_1$ to channel {channels[q]}")
+    ax.set_title(f"(a) Harmonic-similarity ranking from query channel {channels[q]}")
+    ax.legend(frameon=False, loc="upper right", fontsize=8)
+
+    # Middle row: query + nearest histograms overlaid
+    ax = fig.add_subplot(gs[1, :])
+    H = analyzer.histograms
+    bin_cents = np.linspace(2.5, 1197.5, H.shape[1])
+    ax.plot(bin_cents, H[q], color="black", lw=1.6,
+             label=f"query ch{channels[q]}")
+    for j in nearest[:3]:
+        ax.plot(bin_cents, H[j], color="seagreen", lw=1.0, alpha=0.6,
+                 label=f"near ch{channels[j]} (W1={D[q,j]:.1f})")
+    ax.set_xlabel("cents"); ax.set_ylabel("histogram weight")
+    ax.set_title("(b) Query histogram (black) overlaid with 3 nearest neighbours")
+    ax.legend(frameon=False, fontsize=8, ncol=2)
+
+    # Bottom row: farthest neighbour histograms
+    ax = fig.add_subplot(gs[2, :])
+    ax.plot(bin_cents, H[q], color="black", lw=1.6,
+             label=f"query ch{channels[q]}")
+    for j in farthest[:3]:
+        ax.plot(bin_cents, H[j], color="crimson", lw=1.0, alpha=0.6,
+                 label=f"far ch{channels[j]} (W1={D[q,j]:.1f})")
+    ax.set_xlabel("cents"); ax.set_ylabel("histogram weight")
+    ax.set_title("(c) Query histogram (black) overlaid with 3 farthest neighbours")
+    ax.legend(frameon=False, fontsize=8, ncol=2)
+
+    fig.suptitle(
+        "Figure 17 — Application: harmonic-neighbour retrieval on real EEG\n"
+        "(unsupervised: indexes channels by tuning similarity from one query)",
+        fontsize=12.5, y=0.995,
+    )
+    fig.savefig(OUT / "17_real_eeg_retrieval.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  saved 17_real_eeg_retrieval.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+for fn in [fig_overview, fig_six_lenses, fig_retrieval]:
+    fn()
+
+print(f"\nAll real-data figures saved into {OUT}")

--- a/scripts/generate_harmonic_sequence_real_tier1.py
+++ b/scripts/generate_harmonic_sequence_real_tier1.py
@@ -1,0 +1,845 @@
+"""
+generate_harmonic_sequence_real_tier1.py
+========================================
+Extended real-EEG explorations of the harmonic_sequence module, covering all
+four "Tier 1" experiments from the proposal:
+
+  A. Sliding-window temporal analysis on a single channel.
+  B. Cross-condition fingerprinting on MNE-Sample auditory vs visual epochs.
+  C. Scientific-pathway demo (harmonicity_spectrum) on the bundled EEG file.
+  D. Frequency-band stratification (delta/theta/alpha/beta/gamma) on the
+     bundled EEG file.
+
+Each experiment is independent, has its own disk cache, and produces one
+publication-quality figure into docs/papers/figures/.
+
+Run:
+    python scripts/generate_harmonic_sequence_real_tier1.py [A|B|C|D|all]
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy.signal import butter, sosfiltfilt
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from biotuner.biotuner_object import compute_biotuner
+from biotuner.harmonic_sequence import HarmonicSequenceAnalyzer
+
+OUT = ROOT / "docs" / "papers" / "figures"
+CACHE_DIR = ROOT / "docs" / "papers"
+OUT.mkdir(parents=True, exist_ok=True)
+
+plt.rcParams.update({
+    "figure.dpi": 110, "savefig.dpi": 140, "font.size": 9,
+    "axes.spines.top": False, "axes.spines.right": False,
+})
+
+EEG_PATH = ROOT / "docs" / "examples" / "data" / "EEG_example.npy"
+SF = 1000
+FREQ_BANDS_FULL = [[1, 3], [3, 7], [7, 12], [12, 18], [18, 30], [30, 45]]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+class StubBt:
+    """Lightweight bt-like object with just `.data, .sf, .peaks, .peaks_ratios,
+    .peaks_metrics` — enough for HarmonicSequenceAnalyzer + the scientific
+    pathway encoder (which needs `.data`)."""
+    def __init__(self, data, sf, peaks, ratios, metrics):
+        self.data = data
+        self.sf = sf
+        self.peaks = peaks
+        self.peaks_ratios = ratios
+        self.peaks_metrics = metrics
+        self.scale_metrics = {}
+
+
+def _safe_extract(sig, sf, freq_bands=None, max_freq=45, n_peaks=4,
+                  precision=0.5, peaks_function="fixed"):
+    """Run compute_biotuner.peaks_extraction with sensible failure handling.
+    Returns (peaks, ratios, metrics_dict)."""
+    bt = compute_biotuner(sf=sf, peaks_function=peaks_function,
+                          precision=precision, n_harm=10)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            kwargs = dict(max_freq=max_freq, n_peaks=n_peaks,
+                          graph=False, min_harms=2, verbose=False)
+            if freq_bands is not None:
+                kwargs["FREQ_BANDS"] = freq_bands
+            bt.peaks_extraction(sig.astype(np.float64), **kwargs)
+            bt.compute_peaks_metrics()
+        except Exception:
+            return [], [], {}
+    peaks = list(bt.peaks) if bt.peaks is not None else []
+    ratios = list(bt.peaks_ratios) if getattr(bt, "peaks_ratios", None) else []
+    metrics = dict(getattr(bt, "peaks_metrics", {}) or {})
+    return peaks, ratios, metrics
+
+
+def _bandpass(sig, low, high, sf, order=4):
+    sos = butter(order, [low, high], btype="bandpass", fs=sf, output="sos")
+    return sosfiltfilt(sos, sig)
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# A. Sliding-window temporal analysis on a single channel
+# ═════════════════════════════════════════════════════════════════════════════
+
+def run_A():
+    print("\n[A] Sliding-window temporal analysis on a concatenated EEG epoch",
+          flush=True)
+    cache = CACHE_DIR / "_tier1_A_cache.npz"
+    # 4 s per channel is too short for meaningful temporal dynamics.
+    # We concatenate 30 channels with a tiny linear crossfade between each
+    # pair to make a 120 s pseudo-continuous recording; then slide 2 s
+    # windows with 0.5 s hop over it. The crossfade keeps the
+    # sample-to-sample step small so peaks_extraction doesn't see a step
+    # discontinuity at the join.
+    raw = np.load(EEG_PATH)
+    CHANNEL_FROM, CHANNEL_TO = 20, 50
+    XFADE = 50         # samples (50 ms) of linear crossfade per join
+    pieces = [raw[c].astype(np.float64) for c in range(CHANNEL_FROM, CHANNEL_TO)]
+    sig_full = pieces[0].copy()
+    for p in pieces[1:]:
+        # crossfade tail of current with head of next
+        tail = sig_full[-XFADE:].copy()
+        head = p[:XFADE].copy()
+        ramp = np.linspace(0, 1, XFADE)
+        blended = tail * (1 - ramp) + head * ramp
+        sig_full = np.concatenate([sig_full[:-XFADE], blended, p[XFADE:]])
+    print(f"    concatenated channels {CHANNEL_FROM}..{CHANNEL_TO-1} "
+          f"with {XFADE}-sample crossfade -> {len(sig_full)} samples "
+          f"({len(sig_full)/SF:.1f} s)")
+    win_len, hop = 2000, 500
+    starts = list(range(0, len(sig_full) - win_len + 1, hop))
+    T = len(starts)
+    print(f"    {T} windows of {win_len/SF:.1f} s with "
+          f"{hop/SF:.2f} s hop", flush=True)
+
+    if cache.exists():
+        npz = np.load(cache, allow_pickle=True)
+        ratios_list = list(npz["ratios_list"])
+        peaks_list = list(npz["peaks_list"])
+        metrics_list = list(npz["metrics_list"])
+        print(f"    loaded cache from {cache.name}", flush=True)
+    else:
+        ratios_list, peaks_list, metrics_list = [], [], []
+        t0 = time.time()
+        for i, s in enumerate(starts):
+            p, r, m = _safe_extract(sig_full[s:s + win_len], SF,
+                                     freq_bands=FREQ_BANDS_FULL,
+                                     max_freq=45, n_peaks=5, precision=1.0)
+            peaks_list.append(p); ratios_list.append(r); metrics_list.append(m)
+            if (i + 1) % 10 == 0 or (i + 1) == T:
+                print(f"      window {i+1}/{T} done  ({time.time()-t0:.1f}s)",
+                      flush=True)
+        np.savez(cache,
+                 ratios_list=np.array(ratios_list, dtype=object),
+                 peaks_list=np.array(peaks_list, dtype=object),
+                 metrics_list=np.array(metrics_list, dtype=object))
+        print(f"    cached to {cache.name}", flush=True)
+
+    # Build bt-like stubs so harmsim is exposed (analyzer's _get_scalar_series
+    # can pull from peaks_metrics)
+    bt_list = []
+    for i, s in enumerate(starts):
+        bt_list.append(StubBt(sig_full[s:s+win_len], SF,
+                              peaks_list[i], ratios_list[i], metrics_list[i]))
+
+    az = HarmonicSequenceAnalyzer.from_biotuner_list(
+        bt_list, tuning="peaks_ratios", n_hist_bins=240,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        az.fit_all(n_states="auto", auto_k_range=(2, 4))
+    print(f"    " + az.summary().replace("\n", "\n    "))
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 10))
+    gs = fig.add_gridspec(4, 3, height_ratios=[1.0, 1.4, 1.2, 1.2],
+                           hspace=0.55, wspace=0.32,
+                           left=0.06, right=0.97, top=0.94, bottom=0.07)
+
+    # (a) Raw signal with channel-boundary marks
+    ax = fig.add_subplot(gs[0, :])
+    t_axis = np.arange(len(sig_full)) / SF
+    ax.plot(t_axis, sig_full * 1e6, color="black", lw=0.3)
+    # Channel boundaries fall every 4 s in the concatenated signal (one
+    # 4-second source channel per join). Subtract the cumulative XFADE
+    # so the line lands on the actual join sample.
+    SOURCE_LEN_S = 4.0
+    n_channels_used = 30
+    for k in range(1, n_channels_used):
+        # each join consumed XFADE samples of overlap
+        x = k * SOURCE_LEN_S - k * XFADE / SF / 2
+        ax.axvline(x, color="steelblue", alpha=0.25, lw=0.6)
+    ax.set_xlim(0, len(sig_full) / SF)
+    ax.set_xlabel("time (s, pseudo-temporal)"); ax.set_ylabel("µV")
+    ax.set_title(f"(a) Concatenated EEG signal "
+                  f"({n_channels_used} channels x 4 s with crossfade)  "
+                  f"— faint blue lines mark channel boundaries")
+
+    # (b) Histogram trajectory + Markov state strip
+    ax = fig.add_subplot(gs[1, :])
+    H = az.histograms
+    im = ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                    extent=[0, T, 0, 1200])
+    labels = az.markov.state_labels_
+    cmap_st = plt.get_cmap("tab10")
+    ymin, ymax = 0, 1200
+    strip = 70
+    for t in range(T):
+        ax.add_patch(plt.Rectangle((t - 0.5, ymax + 12), 1, strip,
+                                    color=cmap_st(int(labels[t]) % 10),
+                                    clip_on=False))
+    ax.set_ylim(0, ymax + strip + 18)
+    ax.set_xlabel("window index"); ax.set_ylabel("cents")
+    ax.set_title("(b) Cents-histogram trajectory + Markov state strip "
+                  f"(K={az.markov.n_states}, "
+                  f"H={az.markov.transition_entropy_:.2f} bits)")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01, label="weight")
+
+    # (c) Flux time series
+    ax = fig.add_subplot(gs[2, 0])
+    flux = az.wasserstein.flux_
+    ax.plot(np.arange(len(flux)), flux, color="black", lw=1.4)
+    z = (flux - flux.mean()) / (flux.std() + 1e-9)
+    for d in np.where(z > 2.0)[0]:
+        ax.scatter(d, flux[d], s=70, color="crimson", zorder=5)
+    ax.set_xlabel("window transition"); ax.set_ylabel("$W_1$ flux")
+    ax.set_title(f"(c) Temporal harmonic flux (mean={flux.mean():.2f})")
+
+    # (d) Latent PC1-PC2 trajectory
+    ax = fig.add_subplot(gs[2, 1])
+    Z = az.latent.trajectory()
+    sc = ax.scatter(Z[:, 0], Z[:, 1], c=np.arange(T), cmap="viridis",
+                     s=46, edgecolor="white", lw=0.6)
+    ax.plot(Z[:, 0], Z[:, 1], color="grey", lw=0.5, alpha=0.5)
+    ax.set_xlabel("PC1"); ax.set_ylabel("PC2")
+    evr = az.latent.explained_variance_ratio_
+    ax.set_title(f"(d) Latent trajectory  ({evr[:2].sum():.0%} var)")
+    fig.colorbar(sc, ax=ax, fraction=0.046, pad=0.04, label="window")
+
+    # (e) DMD eigenvalues — now this can find genuine oscillation
+    ax = fig.add_subplot(gs[2, 2])
+    if az.dmd is not None and len(az.dmd.eigenvalues_) > 0:
+        eigs = az.dmd.eigenvalues_
+        theta = np.linspace(0, 2 * np.pi, 200)
+        ax.plot(np.cos(theta), np.sin(theta), color="grey", lw=0.8, ls="--")
+        osc, idx = az.dmd.oscillatory_modes(threshold=0.15)
+        is_osc = np.zeros(len(eigs), dtype=bool); is_osc[idx] = True
+        ax.scatter(eigs[~is_osc].real, eigs[~is_osc].imag,
+                    s=60, color="#888", alpha=0.75, label="decaying")
+        ax.scatter(eigs[is_osc].real, eigs[is_osc].imag,
+                    s=130, color="crimson", marker="*",
+                    label=f"|λ|≈1 ({len(idx)})")
+        ax.set_xlim(-1.3, 1.3); ax.set_ylim(-1.3, 1.3); ax.set_aspect("equal")
+        ax.axhline(0, color="grey", lw=0.3); ax.axvline(0, color="grey", lw=0.3)
+        ax.set_xlabel(r"Re($\lambda$)"); ax.set_ylabel(r"Im($\lambda$)")
+        ax.set_title("(e) DMD spectrum  (temporal: oscillation possible)")
+        ax.legend(frameon=False, fontsize=7)
+
+    # (f) Per-window harmsim curve
+    ax = fig.add_subplot(gs[3, :])
+    hs = np.array([m.get("harmsim", np.nan) for m in metrics_list],
+                  dtype=float)
+    cons = np.array([m.get("cons", np.nan) for m in metrics_list],
+                    dtype=float)
+    ax.plot(np.arange(T), hs, "o-", color="#4C72B0", label="harmsim",
+             lw=1.3, markersize=5)
+    ax2 = ax.twinx()
+    ax2.plot(np.arange(T), cons, "s--", color="#DD8452", label="cons",
+              lw=1.0, markersize=4, alpha=0.85)
+    ax.set_xlabel("window"); ax.set_ylabel("harmsim", color="#4C72B0")
+    ax2.set_ylabel("cons", color="#DD8452")
+    ax.set_title("(f) Per-window scalar metrics from peaks_metrics — "
+                  "the temporal harmonic-similarity trace")
+    h1, l1 = ax.get_legend_handles_labels()
+    h2, l2 = ax2.get_legend_handles_labels()
+    ax.legend(h1 + h2, l1 + l2, frameon=False, loc="upper right", fontsize=8)
+
+    fig.suptitle(
+        "Figure 18 — Experiment A: sliding-window temporal analysis "
+        f"on EEG_example.npy channel 39  ({T} windows)",
+        fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "18_real_eeg_sliding_window.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 18_real_eeg_sliding_window.png")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# B. Cross-condition fingerprinting on MNE-Sample auditory vs visual epochs
+# ═════════════════════════════════════════════════════════════════════════════
+
+def run_B():
+    print("\n[B] Cross-condition fingerprinting on MNE-Sample auditory vs visual",
+          flush=True)
+    cache = CACHE_DIR / "_tier1_B_cache.npz"
+    N_EPOCHS = 15
+    MAX_FREQ_B = 30        # tighter band for faster peaks_extraction
+
+    if cache.exists():
+        npz = np.load(cache, allow_pickle=True)
+        ratios_aud = list(npz["ratios_aud"])
+        ratios_vis = list(npz["ratios_vis"])
+        metrics_aud = list(npz["metrics_aud"])
+        metrics_vis = list(npz["metrics_vis"])
+        sig_aud = npz["sig_aud"]
+        sig_vis = npz["sig_vis"]
+        sf_used = float(npz["sf_used"])
+        print(f"    loaded cache from {cache.name}")
+    else:
+        import mne
+        from mne.datasets import sample
+        sample_dir = Path(sample.data_path()) / "MEG" / "sample"
+        raw_fname = sample_dir / "sample_audvis_raw.fif"
+        event_fname = sample_dir / "sample_audvis_raw-eve.fif"
+        print(f"    loading {raw_fname.name} ...")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False)
+            raw.pick(["eeg"]).filter(1, MAX_FREQ_B, verbose=False, n_jobs=1)
+            events = mne.read_events(event_fname)
+            # Event IDs: 1=aud-left, 2=aud-right, 3=vis-left, 4=vis-right
+            event_id = {"auditory_left": 1, "auditory_right": 2,
+                        "visual_left": 3, "visual_right": 4}
+            epochs = mne.Epochs(raw, events, event_id=event_id,
+                                tmin=-0.1, tmax=1.0, baseline=(None, 0),
+                                preload=True, verbose=False)
+        sf_used = float(epochs.info["sfreq"])
+        # Average 5 adjacent EEG channels per epoch — this gives a much
+        # cleaner signal than any single channel and yields more meaningful
+        # peak extraction. We pick a posterior cluster which should
+        # respond strongly to both conditions in different ways.
+        ch_names = [f"EEG 0{n:02d}" for n in (54, 55, 56, 57, 58)]
+        ch_idx = [epochs.ch_names.index(c) for c in ch_names]
+        print(f"    averaging across {ch_names}, sf={sf_used:.0f} Hz, "
+              f"{len(epochs)} total epochs", flush=True)
+
+        aud = epochs["auditory_left", "auditory_right"].get_data()
+        vis = epochs["visual_left", "visual_right"].get_data()
+        # mean across the 5 channels -> (n_epochs, n_times)
+        sig_aud = aud[:N_EPOCHS, ch_idx, :].mean(axis=1).astype(np.float64)
+        sig_vis = vis[:N_EPOCHS, ch_idx, :].mean(axis=1).astype(np.float64)
+        print(f"    aud epochs: {sig_aud.shape}, vis epochs: {sig_vis.shape}",
+              flush=True)
+
+        def _extract(sigs, label):
+            rats, mets = [], []
+            t0 = time.time()
+            for i, s in enumerate(sigs):
+                _, r, m = _safe_extract(s, sf_used,
+                                         freq_bands=[[1,4],[4,8],[8,12],
+                                                     [12,18],[18,30]],
+                                         max_freq=MAX_FREQ_B, n_peaks=5,
+                                         precision=1.0)
+                rats.append(r); mets.append(m)
+                print(f"      {label} {i+1}/{len(sigs)} "
+                      f"({time.time()-t0:.1f}s)", flush=True)
+            return rats, mets
+
+        ratios_aud, metrics_aud = _extract(sig_aud, "aud")
+        ratios_vis, metrics_vis = _extract(sig_vis, "vis")
+        np.savez(cache,
+                 ratios_aud=np.array(ratios_aud, dtype=object),
+                 ratios_vis=np.array(ratios_vis, dtype=object),
+                 metrics_aud=np.array(metrics_aud, dtype=object),
+                 metrics_vis=np.array(metrics_vis, dtype=object),
+                 sig_aud=sig_aud, sig_vis=sig_vis,
+                 sf_used=np.array(sf_used))
+        print(f"    cached to {cache.name}")
+
+    # Build analyzers per condition
+    def _make_az(ratios, metrics):
+        # Use stub bts so harmsim flows in via peaks_metrics
+        bts = [StubBt(np.array([]), sf_used, [], r, m)
+               for r, m in zip(ratios, metrics)]
+        az = HarmonicSequenceAnalyzer.from_biotuner_list(
+            bts, tuning="peaks_ratios", n_hist_bins=240,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            az.fit_all(n_states="auto", auto_k_range=(2, 5))
+        return az
+
+    az_aud = _make_az(ratios_aud, metrics_aud)
+    az_vis = _make_az(ratios_vis, metrics_vis)
+
+    print(f"    AUD: {az_aud.summary().splitlines()[1]}")
+    print(f"    VIS: {az_vis.summary().splitlines()[1]}")
+
+    def _fingerprint(az):
+        flux = az.wasserstein.flux_
+        beta = az.topology.betti_numbers_ if az.topology else np.array([0, 0])
+        evr = (az.latent.explained_variance_ratio_[:2].sum()
+               if az.latent else 0.0)
+        eigs = (np.abs(az.dmd.eigenvalues_) if az.dmd is not None
+                else np.array([]))
+        osc = float((np.abs(eigs - 1.0) < 0.1).mean()) if len(eigs) else 0.0
+        return {
+            "flux_mean": float(flux.mean()),
+            "flux_std": float(flux.std()),
+            "K_markov": float(az.markov.n_states),
+            "H_markov": float(az.markov.transition_entropy_),
+            "var_PC1+2": float(evr),
+            "beta0": float(beta[0]),
+            "osc_frac": osc,
+            "H_grammar": float(az.grammar.transition_entropy_)
+                         if az.grammar else 0.0,
+            "vocab": float(len(az.grammar.vocabulary_)) if az.grammar else 0,
+        }
+
+    fp_aud = _fingerprint(az_aud)
+    fp_vis = _fingerprint(az_vis)
+    metrics = list(fp_aud.keys())
+    aud_vals = np.array([fp_aud[m] for m in metrics])
+    vis_vals = np.array([fp_vis[m] for m in metrics])
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14, 9))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.0, 1.0, 1.0],
+                           hspace=0.55, wspace=0.30,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    # (a-b) Histogram trajectories side-by-side
+    # Sparse cents histograms with ~5 peaks per epoch leave most cells at
+    # zero; we set vmax to the 95th percentile of the union so the
+    # populated cells are clearly visible.
+    H_a, H_v = az_aud.histograms, az_vis.histograms
+    vmax = float(np.percentile(np.concatenate([H_a.ravel(), H_v.ravel()]),
+                               99))
+    vmax = max(vmax, 1e-3)
+    ax = fig.add_subplot(gs[0, :2])
+    im = ax.imshow(H_a.T, aspect="auto", origin="lower", cmap="magma",
+                    vmin=0, vmax=vmax,
+                    extent=[0, len(ratios_aud), 0, 1200])
+    ax.set_xlabel("auditory epoch"); ax.set_ylabel("cents")
+    ax.set_title(f"(a) Auditory cents-histogram trajectory "
+                  f"({len(ratios_aud)} epochs, 5-channel avg)")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+
+    ax = fig.add_subplot(gs[1, :2])
+    im = ax.imshow(H_v.T, aspect="auto", origin="lower", cmap="magma",
+                    vmin=0, vmax=vmax,
+                    extent=[0, len(ratios_vis), 0, 1200])
+    ax.set_xlabel("visual epoch"); ax.set_ylabel("cents")
+    ax.set_title(f"(b) Visual cents-histogram trajectory "
+                  f"({len(ratios_vis)} epochs, 5-channel avg)")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01)
+
+    # (c) Harmsim distribution per condition (violin)
+    ax = fig.add_subplot(gs[0, 2])
+    hs_aud = np.array([m.get("harmsim", np.nan) for m in metrics_aud],
+                      dtype=float)
+    hs_vis = np.array([m.get("harmsim", np.nan) for m in metrics_vis],
+                      dtype=float)
+    hs_aud = hs_aud[np.isfinite(hs_aud)]
+    hs_vis = hs_vis[np.isfinite(hs_vis)]
+    parts = ax.violinplot([hs_aud, hs_vis], positions=[0, 1],
+                           showmeans=True, widths=0.7)
+    for pc, c in zip(parts["bodies"], ["#4C72B0", "#DD8452"]):
+        pc.set_facecolor(c); pc.set_alpha(0.7)
+    ax.set_xticks([0, 1]); ax.set_xticklabels(["auditory", "visual"])
+    ax.set_ylabel("harmsim")
+    from scipy.stats import mannwhitneyu
+    u, p = mannwhitneyu(hs_aud, hs_vis, alternative="two-sided")
+    ax.set_title(f"(c) Harmsim per epoch\n"
+                  f"Mann-Whitney p = {p:.3f}", fontsize=9.5)
+
+    # (d) Flux time series both conditions
+    ax = fig.add_subplot(gs[1, 2])
+    ax.plot(az_aud.wasserstein.flux_, color="#4C72B0", lw=1.3,
+             label=f"auditory (μ={fp_aud['flux_mean']:.1f})")
+    ax.plot(az_vis.wasserstein.flux_, color="#DD8452", lw=1.3,
+             label=f"visual (μ={fp_vis['flux_mean']:.1f})")
+    ax.set_xlabel("epoch transition"); ax.set_ylabel("$W_1$ flux")
+    ax.set_title("(d) Between-epoch flux")
+    ax.legend(frameon=False, fontsize=8)
+
+    # (e) Side-by-side fingerprint bars
+    ax = fig.add_subplot(gs[2, :2])
+    x = np.arange(len(metrics))
+    width = 0.36
+    # Normalise per metric so they fit on one chart
+    pair = np.stack([aud_vals, vis_vals])
+    norm = pair / (np.maximum(pair.max(axis=0), 1e-9))
+    ax.bar(x - width/2, norm[0], width, color="#4C72B0", label="auditory")
+    ax.bar(x + width/2, norm[1], width, color="#DD8452", label="visual")
+    for i, m in enumerate(metrics):
+        ax.text(i - width/2, norm[0, i] + 0.02, f"{aud_vals[i]:.2g}",
+                 ha="center", fontsize=7, color="#4C72B0")
+        ax.text(i + width/2, norm[1, i] + 0.02, f"{vis_vals[i]:.2g}",
+                 ha="center", fontsize=7, color="#DD8452")
+    ax.set_xticks(x); ax.set_xticklabels(metrics, rotation=30, ha="right")
+    ax.set_ylabel("value (per-metric normalised)")
+    ax.set_title("(e) 9-metric fingerprint — values printed in absolute units")
+    ax.legend(frameon=False, fontsize=8, loc="upper right")
+    ax.set_ylim(0, 1.18)
+
+    # (f) Markov transition matrices side-by-side
+    ax = fig.add_subplot(gs[2, 2])
+    Tm_a = az_aud.markov.transition_matrix_
+    Tm_v = az_vis.markov.transition_matrix_
+    Ka, Kv = Tm_a.shape[0], Tm_v.shape[0]
+    # Plot two heatmaps stacked
+    combined = np.zeros((Ka, Ka + 1 + Kv))
+    combined[:Ka, :Ka] = Tm_a
+    if Kv == Ka:
+        combined[:Kv, Ka+1:] = Tm_v
+    im = ax.imshow(combined, cmap="rocket_r", vmin=0, vmax=1, aspect="auto")
+    ax.set_xticks([Ka/2-0.5, Ka + Kv/2 + 0.5])
+    ax.set_xticklabels([f"AUD (K={Ka})", f"VIS (K={Kv})"], fontsize=9)
+    ax.set_yticks([])
+    ax.set_title(f"(f) Markov transition matrices\n"
+                  f"H_aud={fp_aud['H_markov']:.2f}, "
+                  f"H_vis={fp_vis['H_markov']:.2f} bits", fontsize=9.5)
+
+    fig.suptitle(
+        "Figure 19 — Experiment B: cross-condition fingerprinting on "
+        "MNE-Sample auditory vs visual epochs", fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "19_real_eeg_cross_condition.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 19_real_eeg_cross_condition.png")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# C. Scientific pathway (harmonicity_spectrum) on EEG_example.npy
+# ═════════════════════════════════════════════════════════════════════════════
+
+def run_C():
+    print("\n[C] Scientific pathway: harmonicity_spectrum vs cents_histogram")
+    # Reuse the cache built by generate_harmonic_sequence_real_data.py
+    src_cache = CACHE_DIR / "_real_eeg_bt_cache.npz"
+    if not src_cache.exists():
+        print(f"    !! requires {src_cache.name} from "
+              "generate_harmonic_sequence_real_data.py")
+        return
+    npz = np.load(src_cache, allow_pickle=True)
+    ratios_list = list(npz["ratios_list"])
+    peaks_list = list(npz["peaks_list"])
+    harmsim_list = npz["harmsim_list"]
+
+    # Need bt objects with `.data` for the harmonicity_spectrum encoder.
+    eeg = np.load(EEG_PATH)
+    CHANNEL_START = 20; N_CHANNELS = 60
+    channels = list(range(CHANNEL_START, CHANNEL_START + N_CHANNELS))
+    metrics_list = [{"harmsim": float(h)} for h in harmsim_list]
+
+    bts = [StubBt(eeg[ch].astype(np.float64), SF,
+                  peaks_list[i], ratios_list[i], metrics_list[i])
+           for i, ch in enumerate(channels)]
+
+    az_cents = HarmonicSequenceAnalyzer.from_biotuner_list(
+        bts, tuning="peaks_ratios",
+        representation="cents_histogram", n_hist_bins=240,
+    )
+    az_spec = HarmonicSequenceAnalyzer.from_biotuner_list(
+        bts, tuning="peaks_ratios",
+        representation="harmonicity_spectrum",
+        representation_kwargs=dict(fmin=1.0, fmax=45.0, precision_hz=0.5,
+                                    metric="harmsim", n_harms=10,
+                                    normalize=True),
+    )
+
+    print("    fitting cents-pathway analyzer...")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        az_cents.fit_markov(n_states="auto", auto_k_range=(2, 6))
+        az_cents.fit_wasserstein()
+        az_cents.fit_latent(latent_dim=3)
+    print(f"    cents:  {az_cents.summary().splitlines()[1]}")
+
+    print("    fitting spectrum-pathway analyzer (slow: encodes harmonicity)")
+    t0 = time.time()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        az_spec.fit_markov(n_states="auto", auto_k_range=(2, 6))
+        az_spec.fit_wasserstein()
+        az_spec.fit_latent(latent_dim=3)
+    print(f"    spectrum: {az_spec.summary().splitlines()[1]} "
+          f"({time.time()-t0:.1f}s)")
+
+    H_cents = az_cents.histograms
+    H_spec = az_spec.features                 # (T, F)
+    spec_freqs = az_spec.features_freqs_      # (F,)
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(14.5, 9))
+    gs = fig.add_gridspec(3, 3, height_ratios=[1.2, 1.2, 1.2],
+                           hspace=0.55, wspace=0.30,
+                           left=0.06, right=0.97, top=0.93, bottom=0.07)
+
+    # (a) cents-histogram trajectory
+    ax = fig.add_subplot(gs[0, :])
+    im = ax.imshow(H_cents.T, aspect="auto", origin="lower", cmap="magma",
+                    extent=[0, H_cents.shape[0], 0, 1200])
+    ax.set_xlabel("channel"); ax.set_ylabel("cents")
+    ax.set_title("(a) MUSICAL pathway — cents-histogram trajectory")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01, label="weight")
+
+    # (b) harmonicity-spectrum trajectory in Hz
+    ax = fig.add_subplot(gs[1, :])
+    im = ax.imshow(H_spec.T, aspect="auto", origin="lower", cmap="viridis",
+                    extent=[0, H_spec.shape[0],
+                             spec_freqs[0], spec_freqs[-1]])
+    ax.set_xlabel("channel"); ax.set_ylabel("frequency (Hz)")
+    ax.set_title("(b) SCIENTIFIC pathway — harmonicity-spectrum trajectory")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01, label="harmonicity")
+
+    # (c) flux comparison
+    ax = fig.add_subplot(gs[2, 0])
+    f_c = az_cents.wasserstein.flux_
+    f_s = az_spec.wasserstein.flux_
+    f_c_n = f_c / (f_c.max() + 1e-9)
+    f_s_n = f_s / (f_s.max() + 1e-9)
+    ax.plot(f_c_n, color="#4C72B0", lw=1.3, label="cents (norm)")
+    ax.plot(f_s_n, color="#55A868", lw=1.3, label="spectrum (norm)")
+    ax.set_xlabel("channel transition"); ax.set_ylabel("normalised flux")
+    from scipy.stats import spearmanr
+    rho, p = spearmanr(f_c, f_s)
+    ax.set_title(f"(c) Flux comparison  "
+                  f"(Spearman ρ = {rho:.2f}, p = {p:.2g})", fontsize=9.5)
+    ax.legend(frameon=False, fontsize=8)
+
+    # (d) Markov state agreement
+    ax = fig.add_subplot(gs[2, 1])
+    lab_c = az_cents.markov.state_labels_
+    lab_s = az_spec.markov.state_labels_
+    T = len(lab_c)
+    cmap_st = plt.get_cmap("tab10")
+    for t in range(T):
+        ax.add_patch(plt.Rectangle((t, 0.55), 1, 0.4,
+                                    color=cmap_st(int(lab_c[t]) % 10)))
+        ax.add_patch(plt.Rectangle((t, 0.05), 1, 0.4,
+                                    color=cmap_st(int(lab_s[t]) % 10)))
+    from sklearn.metrics import adjusted_rand_score
+    ari = adjusted_rand_score(lab_c, lab_s)
+    ax.set_xlim(0, T); ax.set_ylim(0, 1)
+    ax.set_yticks([0.25, 0.75]); ax.set_yticklabels(["spectrum", "cents"])
+    ax.set_xlabel("channel")
+    ax.set_title(f"(d) Markov label agreement  "
+                  f"(adjusted Rand index = {ari:.2f})", fontsize=9.5)
+
+    # (e) PCA scatter for both
+    ax = fig.add_subplot(gs[2, 2])
+    Zc = az_cents.latent.trajectory()
+    Zs = az_spec.latent.trajectory()
+    Zc_n = (Zc - Zc.mean(axis=0)) / (Zc.std(axis=0) + 1e-9)
+    Zs_n = (Zs - Zs.mean(axis=0)) / (Zs.std(axis=0) + 1e-9)
+    ax.scatter(Zc_n[:, 0], Zc_n[:, 1], s=28, c="#4C72B0", alpha=0.6,
+                label="cents path", edgecolor="none")
+    ax.scatter(Zs_n[:, 0], Zs_n[:, 1], s=28, c="#55A868", alpha=0.6,
+                label="spectrum path", edgecolor="none")
+    ax.set_xlabel("PC1 (z-scored)"); ax.set_ylabel("PC2 (z-scored)")
+    ax.set_title("(e) Latent overlay  "
+                  f"(cents {az_cents.latent.explained_variance_ratio_[:2].sum():.0%}, "
+                  f"spec {az_spec.latent.explained_variance_ratio_[:2].sum():.0%})",
+                  fontsize=9.5)
+    ax.legend(frameon=False, fontsize=8)
+
+    fig.suptitle(
+        "Figure 20 — Experiment C: same EEG, two pathways "
+        "(musical cents vs scientific harmonicity-spectrum)",
+        fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "20_real_eeg_two_pathways.png", bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 20_real_eeg_two_pathways.png")
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# D. Frequency-band stratification on EEG_example.npy
+# ═════════════════════════════════════════════════════════════════════════════
+
+def run_D():
+    print("\n[D] Frequency-band stratification (delta/theta/alpha/beta/gamma)")
+    cache = CACHE_DIR / "_tier1_D_cache.npz"
+    eeg = np.load(EEG_PATH)
+    N_CHANNELS = 30
+    CHANNEL_START = 25
+    channels = list(range(CHANNEL_START, CHANNEL_START + N_CHANNELS))
+
+    BANDS = [
+        ("delta", 1, 4,   [[1, 2], [2, 3], [3, 4]]),
+        ("theta", 4, 8,   [[4, 5], [5, 6], [6, 7], [7, 8]]),
+        ("alpha", 8, 12,  [[8, 9], [9, 10], [10, 11], [11, 12]]),
+        ("beta",  12, 30, [[12, 16], [16, 20], [20, 24], [24, 30]]),
+        ("gamma", 30, 45, [[30, 35], [35, 40], [40, 45]]),
+    ]
+
+    if cache.exists():
+        npz = np.load(cache, allow_pickle=True)
+        results = {b[0]: {"ratios": list(npz[f"{b[0]}_ratios"]),
+                           "metrics": list(npz[f"{b[0]}_metrics"])}
+                   for b in BANDS}
+        print(f"    loaded cache from {cache.name}")
+    else:
+        results = {}
+        for name, low, high, freq_bands in BANDS:
+            print(f"    extracting {name}-band [{low}-{high} Hz]"
+                  f" on {N_CHANNELS} channels...")
+            t0 = time.time()
+            rats, mets = [], []
+            for ch in channels:
+                filt = _bandpass(eeg[ch], low, high, SF)
+                _, r, m = _safe_extract(filt, SF, freq_bands=freq_bands,
+                                         max_freq=high + 2, n_peaks=4,
+                                         precision=0.5)
+                rats.append(r); mets.append(m)
+            results[name] = {"ratios": rats, "metrics": mets}
+            print(f"      {name} done ({time.time()-t0:.1f}s, "
+                  f"{sum(1 for r in rats if r)}/{N_CHANNELS} valid)")
+
+        np.savez(cache, **{f"{n}_ratios": np.array(results[n]["ratios"],
+                                                      dtype=object)
+                              for n in [b[0] for b in BANDS]},
+                          **{f"{n}_metrics": np.array(results[n]["metrics"],
+                                                      dtype=object)
+                              for n in [b[0] for b in BANDS]})
+        print(f"    cached to {cache.name}")
+
+    # Fit one analyzer per band
+    fingerprints = {}
+    fitted = {}
+    for name, _low, _high, _ in BANDS:
+        ratios = results[name]["ratios"]
+        metrics = results[name]["metrics"]
+        bts = [StubBt(np.array([]), SF, [], r, m)
+               for r, m in zip(ratios, metrics)]
+        az = HarmonicSequenceAnalyzer.from_biotuner_list(
+            bts, tuning="peaks_ratios", n_hist_bins=240,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            az.fit_all(n_states="auto", auto_k_range=(2, 5))
+        fitted[name] = az
+        flux = az.wasserstein.flux_
+        beta = az.topology.betti_numbers_ if az.topology else np.array([0, 0])
+        evr = (az.latent.explained_variance_ratio_[:2].sum()
+               if az.latent else 0.0)
+        hs = np.array([m.get("harmsim", np.nan) for m in metrics],
+                      dtype=float)
+        hs = hs[np.isfinite(hs)]
+        fingerprints[name] = {
+            "flux_mean": float(flux.mean()),
+            "K_markov": float(az.markov.n_states),
+            "H_markov": float(az.markov.transition_entropy_),
+            "var_PC1+2": float(evr),
+            "beta0": float(beta[0]),
+            "vocab": float(len(az.grammar.vocabulary_)) if az.grammar else 0,
+            "H_grammar": (float(az.grammar.transition_entropy_)
+                          if az.grammar else 0.0),
+            "harmsim_mean": float(hs.mean()) if len(hs) else 0.0,
+            "harmsim_std": float(hs.std()) if len(hs) else 0.0,
+        }
+        print(f"    {name}: {fingerprints[name]}")
+
+    # ── Figure ────────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(15, 9.5))
+    gs = fig.add_gridspec(3, 5, height_ratios=[1.4, 1.1, 1.1],
+                           hspace=0.55, wspace=0.35,
+                           left=0.05, right=0.97, top=0.93, bottom=0.07)
+
+    band_names = [b[0] for b in BANDS]
+    band_colours = ["#4C72B0", "#55A868", "#C44E52", "#8172B2", "#CCB974"]
+
+    # Row 1: per-band cents-histogram heatmaps
+    for col, name in enumerate(band_names):
+        ax = fig.add_subplot(gs[0, col])
+        H = fitted[name].histograms
+        ax.imshow(H.T, aspect="auto", origin="lower", cmap="magma",
+                   extent=[0, H.shape[0], 0, 1200])
+        ax.set_title(f"{name}  [{BANDS[col][1]}-{BANDS[col][2]} Hz]")
+        ax.set_xlabel("channel")
+        if col == 0:
+            ax.set_ylabel("cents")
+        else:
+            ax.set_yticklabels([])
+
+    # Row 2: 4 fingerprint metrics across bands
+    chosen_metrics = ["H_markov", "flux_mean", "beta0", "harmsim_mean"]
+    titles_m = [
+        r"(b) Markov transition entropy $H$ (bits)",
+        "(c) Mean $W_1$ flux (cents-bin units)",
+        r"(d) Topological basin count $\beta_0$",
+        "(e) Mean harmsim across channels",
+    ]
+    for col, (mkey, title) in enumerate(zip(chosen_metrics, titles_m)):
+        ax = fig.add_subplot(gs[1, col])
+        vals = [fingerprints[n][mkey] for n in band_names]
+        bars = ax.bar(band_names, vals, color=band_colours)
+        ax.set_title(title, fontsize=9.5)
+        ax.tick_params(axis="x", labelsize=8)
+        for b, v in zip(bars, vals):
+            ax.text(b.get_x() + b.get_width()/2, v + 0.02 * max(vals),
+                     f"{v:.2g}", ha="center", fontsize=8)
+
+    # Empty last cell row 2 - put grammar entropy there
+    ax = fig.add_subplot(gs[1, 4])
+    vals = [fingerprints[n]["H_grammar"] for n in band_names]
+    bars = ax.bar(band_names, vals, color=band_colours)
+    ax.set_title(r"(f) Grammar entropy $H_g$ (bits)", fontsize=9.5)
+    ax.tick_params(axis="x", labelsize=8)
+    for b, v in zip(bars, vals):
+        if max(vals) > 0:
+            ax.text(b.get_x() + b.get_width()/2, v + 0.02 * max(vals),
+                     f"{v:.2g}", ha="center", fontsize=8)
+
+    # Row 3: heatmap of all fingerprints
+    ax = fig.add_subplot(gs[2, :])
+    full_metrics = list(fingerprints[band_names[0]].keys())
+    M = np.array([[fingerprints[b][m] for m in full_metrics]
+                  for b in band_names])
+    Mn = (M - M.min(axis=0)) / (M.max(axis=0) - M.min(axis=0) + 1e-9)
+    im = ax.imshow(Mn, aspect="auto", cmap="viridis")
+    for i in range(Mn.shape[0]):
+        for j in range(Mn.shape[1]):
+            ax.text(j, i, f"{M[i, j]:.2g}", ha="center", va="center",
+                     fontsize=7.5,
+                     color="white" if Mn[i, j] > 0.55 else "black")
+    ax.set_xticks(range(len(full_metrics)))
+    ax.set_xticklabels(full_metrics, rotation=30, ha="right", fontsize=8)
+    ax.set_yticks(range(len(band_names)))
+    ax.set_yticklabels(band_names, fontsize=9)
+    ax.set_title("(g) Per-band fingerprint matrix  "
+                  "(raw values shown, colour = column-normalised)")
+
+    fig.suptitle("Figure 21 — Experiment D: per-band stratification of "
+                  f"{N_CHANNELS} EEG channels", fontsize=12.5, y=0.985)
+    fig.savefig(OUT / "21_real_eeg_band_stratification.png",
+                 bbox_inches="tight")
+    plt.close(fig)
+    print("    saved 21_real_eeg_band_stratification.png")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+EXPERIMENTS = {"A": run_A, "B": run_B, "C": run_C, "D": run_D}
+
+
+if __name__ == "__main__":
+    which = sys.argv[1] if len(sys.argv) > 1 else "all"
+    if which == "all":
+        for k in ["A", "B", "C", "D"]:
+            EXPERIMENTS[k]()
+    elif which in EXPERIMENTS:
+        EXPERIMENTS[which]()
+    else:
+        print(f"Usage: {sys.argv[0]} [A|B|C|D|all]")
+        sys.exit(2)
+    print(f"\nAll requested experiments done. Figures in {OUT}")

--- a/scripts/test_harmonic_sequence_capabilities.py
+++ b/scripts/test_harmonic_sequence_capabilities.py
@@ -1,0 +1,553 @@
+"""
+test_harmonic_sequence_capabilities.py
+======================================
+End-to-end capability check for ``biotuner.harmonic_sequence``.
+
+Synthesises a controlled sequence of biosignals whose harmonic content
+drifts between a "just major" and "just minor" regime, runs the full
+HarmonicSequenceAnalyzer pipeline, and prints what each of the six
+approaches reports — together with a pass / fail verdict against a
+hand-derived expectation.
+
+Run:
+    python scripts/test_harmonic_sequence_capabilities.py
+
+Optional flags:
+    --skip-bt        Use synthetic ratio sequences only (no compute_biotuner).
+    --no-midi        Skip MIDI/SCL export.
+    --outdir <path>  Where to write generated artifacts (default: ./out_hseq).
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import warnings
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+# Make sure the repo root is importable when run from anywhere
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from biotuner.harmonic_sequence import (
+    HarmonicDMD,
+    HarmonicGrammar,
+    HarmonicLatentSpace,
+    HarmonicMarkov,
+    HarmonicSequenceAnalyzer,
+    HarmonicTopology,
+    WassersteinTrajectory,
+    encode_histograms,
+    encode_ji_matrix,
+    histogram_to_ratios,
+    histogram_to_scl,
+    histograms_to_midi,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pretty printing
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Force UTF-8 stdout on Windows so any unicode in metric labels doesn't crash.
+if hasattr(sys.stdout, "reconfigure"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+# ANSI colours work on Win10+ terminals; harmless if not rendered.
+GREEN, RED, YELLOW, BLUE, RESET = "\033[32m", "\033[31m", "\033[33m", "\033[36m", "\033[0m"
+RESULTS: list[tuple[str, str, str]] = []  # (section, status, message)
+
+
+def section(title: str) -> None:
+    bar = "=" * 72
+    print(f"\n{BLUE}{bar}\n  {title}\n{bar}{RESET}")
+
+
+def report(name: str, ok: bool, msg: str = "") -> None:
+    tag = f"{GREEN}PASS{RESET}" if ok else f"{RED}FAIL{RESET}"
+    print(f"  [{tag}] {name}" + (f"  -- {msg}" if msg else ""))
+    RESULTS.append((name, "PASS" if ok else "FAIL", msg))
+
+
+def info(msg: str) -> None:
+    print(f"  {YELLOW}*{RESET} {msg}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Synthetic data
+# ─────────────────────────────────────────────────────────────────────────────
+
+JUST_MAJOR = [1.0, 9 / 8, 5 / 4, 4 / 3, 3 / 2, 5 / 3, 15 / 8]   # 7-note JI major
+JUST_MINOR = [1.0, 9 / 8, 6 / 5, 4 / 3, 3 / 2, 8 / 5, 9 / 5]    # 7-note JI minor
+
+
+def synthetic_ratio_sequence(repeats: int = 4) -> List[List[float]]:
+    """Alternating major/minor regimes with small drift inside each block."""
+    seq: List[List[float]] = []
+    rng = np.random.default_rng(0)
+    for r in range(repeats):
+        # 3 major frames with a tiny cents-drift
+        for k in range(3):
+            jitter = 1.0 + 0.002 * (k - 1) + 0.0005 * rng.standard_normal(len(JUST_MAJOR))
+            seq.append([float(x * j) for x, j in zip(JUST_MAJOR, jitter)])
+        # 3 minor frames with a tiny cents-drift
+        for k in range(3):
+            jitter = 1.0 + 0.002 * (k - 1) + 0.0005 * rng.standard_normal(len(JUST_MINOR))
+            seq.append([float(x * j) for x, j in zip(JUST_MINOR, jitter)])
+    return seq
+
+
+def build_bt_list(n_blocks: int = 3, sf: int = 1000, duration: float = 4.0):
+    """Build a small list of fitted compute_biotuner objects.
+
+    Each window's signal is a harmonic stack whose fundamental drifts so the
+    sequence has measurable harmonic motion across windows.
+    """
+    from biotuner.biotuner_object import compute_biotuner
+    rng = np.random.default_rng(42)
+
+    def _signal(freqs):
+        t = np.linspace(0, duration, int(sf * duration), endpoint=False)
+        sig = sum((1.0 / (i + 1)) * np.sin(2 * np.pi * f * t)
+                  for i, f in enumerate(freqs))
+        sig += 0.02 * rng.standard_normal(len(t))
+        return sig.astype(np.float64)
+
+    # Two regimes: "alpha-stack" and "shifted alpha-stack"
+    freq_set_A = [2, 5, 10, 20, 40]
+    freq_set_B = [2, 4.8, 7.2, 14.4, 28.8]
+    freq_seq = []
+    for _ in range(n_blocks):
+        freq_seq += [freq_set_A, freq_set_A, freq_set_B, freq_set_B]
+
+    bts = []
+    for freqs in freq_seq:
+        bt = compute_biotuner(sf=sf, peaks_function="fixed", precision=0.5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            bt.peaks_extraction(_signal(freqs), n_peaks=5,
+                                precision=0.5, min_freq=1.0, max_freq=50.0)
+            try:
+                bt.compute_peaks_metrics()
+            except Exception:
+                pass
+        bts.append(bt)
+    return bts
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Capability checks
+# ─────────────────────────────────────────────────────────────────────────────
+
+def check_encoders(ratios_list):
+    section("1 — Stateless encoders")
+
+    H = encode_histograms(ratios_list, n_bins=240)
+    info(f"cents histogram shape: {H.shape}")
+    row_sums = H.sum(axis=1)
+    report(
+        "histograms normalised per row",
+        np.allclose(row_sums[row_sums > 0], 1.0),
+        f"max |Σ-1| = {abs(row_sums - 1).max():.3g}",
+    )
+
+    # Known landmarks: a 3:2 (~702¢) ratio must light a bin near 702/5 = 140
+    H1 = encode_histograms([[1.5]], n_bins=240)
+    fifth_bin = int(round(1200 * np.log2(1.5) / 5))
+    report(
+        "perfect fifth lands in expected bin",
+        H1[0, fifth_bin] > 0,
+        f"bin {fifth_bin} has weight {H1[0, fifth_bin]:.2f}",
+    )
+
+    # JI matrix should mark known intervals
+    X, labels = encode_ji_matrix([[5 / 4, 3 / 2]], tolerance_cents=20.0)
+    n_hits = int(X.sum())
+    report(
+        "JI matrix labels known intervals",
+        n_hits >= 2,
+        f"{n_hits} of {len(labels)} interval slots matched",
+    )
+
+    return H
+
+
+def check_bridge(H, outdir: Path, want_midi: bool):
+    section("2 — Decoding bridge (histogram → ratios / .scl / MIDI)")
+
+    ratios = histogram_to_ratios(H[0], include_unison=False, include_octave=False)
+    info(f"decoded {len(ratios)} ratios from frame 0: " +
+         ", ".join(f"{r:.4f}" for r in ratios[:6]) + (" …" if len(ratios) > 6 else ""))
+    report(
+        "round-trip recovers ≥ 1 ratio",
+        len(ratios) >= 1,
+        "fails only if histogram peak detection misses all peaks",
+    )
+
+    # Round-trip distance check on JUST_MAJOR (the canonical input)
+    H_one = encode_histograms([JUST_MAJOR])[0]
+    rec = histogram_to_ratios(H_one, include_unison=False, include_octave=False)
+    cents_orig = sorted(1200 * np.log2(r) for r in JUST_MAJOR if r > 0)
+    cents_rec = sorted(1200 * np.log2(r) for r in rec)
+    # cents_orig has 7 entries (unison at 0¢); decoded has ≤7; compare overlap
+    if len(cents_rec) >= len(cents_orig) - 2:
+        max_err = max(min(abs(co - cr) for cr in cents_rec) for co in cents_orig if co > 0)
+        report(
+            "round-trip cents error ≤ 5¢ (one bin)",
+            max_err <= 5.0,
+            f"worst cents error = {max_err:.2f}¢",
+        )
+    else:
+        report("round-trip cents error ≤ 5¢ (one bin)", False,
+               f"decoded only {len(cents_rec)} of {len(cents_orig)} intervals")
+
+    # SCL export (string, no disk)
+    scl = histogram_to_scl(H[0], name="hseq_test", write=False)
+    has_header = scl.lstrip().startswith("!")
+    report("SCL export produces valid header", has_header,
+           f"first line: {scl.splitlines()[0]!r}")
+
+    if not want_midi:
+        info("MIDI export skipped (--no-midi).")
+        return
+
+    try:
+        outdir.mkdir(parents=True, exist_ok=True)
+        cwd = os.getcwd()
+        os.chdir(outdir)
+        try:
+            mid = histograms_to_midi(
+                H[:8], filename="hseq_test", base_freq=220.0,
+                duration_beats=1.0, n_peaks=4, microtonal=True,
+            )
+        finally:
+            os.chdir(cwd)
+        n_tracks = len(mid.tracks)
+        report("MIDI export wrote a multi-track file", n_tracks >= 1,
+               f"{n_tracks} tracks, file at {outdir/'hseq_test.mid'}")
+    except Exception as exc:
+        report("MIDI export wrote a multi-track file", False, f"exception: {exc}")
+
+
+def check_markov(analyzer: HarmonicSequenceAnalyzer):
+    section("3 — Approach 1: HarmonicMarkov")
+
+    mk = analyzer.fit_markov(n_states="auto", auto_k_range=(2, 6))
+    info(f"selected K = {mk.n_states} (silhouette scores: {mk.silhouette_scores_})")
+
+    T = mk.transition_matrix_
+    rows_normalised = np.allclose(T.sum(axis=1), 1.0)
+    report("transition rows sum to 1", rows_normalised,
+           f"row sums = {T.sum(axis=1)}")
+
+    pi = mk.steady_state_
+    report("stationary distribution is a probability vector",
+           np.isclose(pi.sum(), 1.0) and (pi >= -1e-9).all(),
+           f"π = {np.round(pi, 3).tolist()}")
+
+    H_trans = mk.transition_entropy_
+    report("transition entropy in [0, log2(K)]",
+           0.0 <= H_trans <= np.log2(mk.n_states) + 1e-9,
+           f"H = {H_trans:.3f} bits  (max = {np.log2(mk.n_states):.3f})")
+
+    # Sanity: the labels alternate when the source data alternates
+    labels = mk.state_labels_
+    n_unique = len(set(labels.tolist()))
+    report("at least 2 distinct states discovered on alternating data",
+           n_unique >= 2, f"{n_unique} unique states in {len(labels)} frames")
+
+    # Predictive interface
+    proba = mk.predict_next_proba(int(labels[0]))
+    report("predict_next_proba returns valid distribution",
+           proba.shape == (mk.n_states,) and np.isclose(proba.sum(), 1.0),
+           f"P(·|s={labels[0]}) = {np.round(proba, 2).tolist()}")
+
+
+def check_wasserstein(analyzer: HarmonicSequenceAnalyzer):
+    section("4 — Approach 2: WassersteinTrajectory")
+
+    wt = analyzer.fit_wasserstein()
+    D = wt.distance_matrix_
+    flux = wt.flux_
+    info(f"distance matrix shape {D.shape}; flux length {len(flux)}")
+
+    report("distance matrix is symmetric, zero-diag",
+           np.allclose(D, D.T) and np.allclose(np.diag(D), 0.0),
+           f"max asym = {np.abs(D - D.T).max():.3g}")
+
+    report("flux is non-negative",
+           (flux >= -1e-12).all(),
+           f"min flux = {flux.min():.4g}")
+
+    # Barycenter: α=0 → h1, α=1 → h2
+    X = analyzer.features
+    if X.shape[0] >= 2:
+        b0 = wt.barycenter(X[0], X[1], alpha=0.0)
+        report("barycenter(α=0) ≈ h1",
+               np.allclose(b0, X[0] / max(X[0].sum(), 1e-9), atol=0.05),
+               "tolerance is loose: barycenter samples 1000 quantile pts")
+
+    # Embedding
+    try:
+        Z = wt.embed(n_components=2)
+        report("MDS embedding returns (T, 2)",
+               Z.shape == (D.shape[0], 2),
+               f"Z range x:[{Z[:,0].min():.2f},{Z[:,0].max():.2f}] "
+               f"y:[{Z[:,1].min():.2f},{Z[:,1].max():.2f}]")
+    except Exception as exc:
+        report("MDS embedding returns (T, 2)", False, f"exception: {exc}")
+
+
+def check_dmd(analyzer: HarmonicSequenceAnalyzer):
+    section("5 — Approach 3: HarmonicDMD")
+
+    if analyzer._bt_list is None:
+        # Without bt objects scalar_metrics is empty; fall back to histogram PCA
+        info("no bt_list → using use_histograms=True path")
+        dmd = analyzer.fit_dmd(use_histograms=True)
+    else:
+        dmd = analyzer.fit_dmd()
+
+    eigs = dmd.eigenvalues_
+    modes = dmd.modes_
+    info(f"rank = {len(eigs)}; mode matrix {modes.shape}")
+    report("eigenvalues finite",
+           np.all(np.isfinite(eigs)),
+           f"|λ| range = [{np.abs(eigs).min():.3g}, {np.abs(eigs).max():.3g}]")
+
+    growth = dmd.growth_rates_
+    freqs = dmd.frequencies_
+    report("growth_rates_ and frequencies_ are real",
+           np.isrealobj(growth) and np.isrealobj(freqs),
+           f"growth ∈ [{growth.min():.3g}, {growth.max():.3g}]")
+
+    osc, idx = dmd.oscillatory_modes(threshold=0.1)
+    info(f"{len(osc)} oscillatory modes (|λ|≈1 within 0.1)")
+
+    pred = dmd.reconstruct(n_steps=4)
+    report("reconstruct returns (n_steps, D)",
+           pred.ndim == 2 and pred.shape[0] == 4,
+           f"shape = {pred.shape}")
+
+
+def check_latent(analyzer: HarmonicSequenceAnalyzer):
+    section("6 — Approach 4: HarmonicLatentSpace")
+
+    ls = analyzer.fit_latent(latent_dim=3)
+    Z = ls.trajectory()
+    info(f"latent trajectory shape {Z.shape}")
+
+    evr = ls.explained_variance_ratio_
+    report("variance ratios in [0,1] and ≤ 1 in total",
+           (evr >= 0).all() and evr.sum() <= 1.0 + 1e-9,
+           f"per-dim = {np.round(evr, 3).tolist()} → sum = {evr.sum():.3f}")
+
+    X = analyzer.features
+    Z2 = ls.encode(X)
+    report("encode is invertible (≤ MSE bound)",
+           ls.reconstruction_error_ < 1e-2,
+           f"MSE = {ls.reconstruction_error_:.4g}")
+
+    Z_path = ls.interpolate(Z[0], Z[-1], n_steps=5)
+    report("interpolate returns (n_steps, latent_dim)",
+           Z_path.shape == (5, ls.latent_dim),
+           f"endpoints match: "
+           f"{np.allclose(Z_path[0], Z[0])} / {np.allclose(Z_path[-1], Z[-1])}")
+
+
+def check_topology(analyzer: HarmonicSequenceAnalyzer):
+    section("7 — Approach 6: HarmonicTopology  (TDA)")
+
+    try:
+        # Use a smooth scalar so the Takens cloud is meaningful
+        scalar = "harmsim" if analyzer._bt_list is not None else "mean_features"
+        top = analyzer.fit_topology(scalar_key=scalar, embedding_dim=3, delay=1)
+    except Exception as exc:
+        report("topology fit", False, f"exception: {exc}")
+        return
+
+    cloud = top.takens_embedding_
+    info(f"Takens cloud shape {cloud.shape}  (d={top.embedding_dim}, τ={top.delay})")
+
+    diag = top.persistence_diagram_
+    info(f"persistence diagrams: {len(diag)} (H0"
+         + (", H1" if len(diag) > 1 else "") + ")")
+
+    beta = top.betti_numbers_
+    info(f"β0 = {beta[0]}, β1 = {beta[1]}")
+
+    fp = top.session_fingerprint()
+    report("session_fingerprint returns 6-vector",
+           fp.shape == (6,) and np.all(np.isfinite(fp)),
+           f"fingerprint = {np.round(fp, 3).tolist()}")
+
+
+def check_grammar(analyzer: HarmonicSequenceAnalyzer):
+    section("8 — Approach 7: HarmonicGrammar")
+
+    gr = analyzer.fit_grammar(n_gram=2)
+    vocab = gr.vocabulary_
+    info(f"vocab size = {len(vocab)}; first token = {set(vocab[0])}")
+
+    top = gr.top_ngrams(3)
+    info("top-3 bigrams (chord1 | chord2 → count):")
+    for gram, count in top:
+        a, b = gram
+        info(f"  {sorted(a)}  →  {sorted(b)}  ×{count}")
+
+    H_g = gr.transition_entropy_
+    report("grammar entropy ≥ 0", H_g >= 0.0, f"H = {H_g:.3f} bits")
+
+    motifs = gr.top_motifs(min_length=2, max_length=3, top_k=3)
+    report("top_motifs returns ≤ top_k entries",
+           1 <= len(motifs) <= 3, f"{len(motifs)} motifs found")
+
+    d = gr.levenshtein(gr.chord_sequence_, gr.chord_sequence_)
+    report("levenshtein(seq, seq) == 0", d == 0, f"d = {d}")
+
+
+def check_orchestrator_and_bridge(
+    analyzer: HarmonicSequenceAnalyzer, outdir: Path, want_midi: bool,
+):
+    section("9 — HarmonicSequenceAnalyzer end-to-end + render bridge")
+
+    print(analyzer.summary())
+
+    # 'observed' source
+    H_obs = analyzer.get_histograms(source="observed")
+    report("get_histograms('observed') shape matches input",
+           H_obs.shape == (len(analyzer.ratios_list), analyzer.n_hist_bins),
+           f"shape = {H_obs.shape}")
+
+    # Wasserstein-driven glissando
+    try:
+        H_glide = analyzer.get_histograms(
+            source="wasserstein_interp", t1=0, t2=len(analyzer.ratios_list) - 1,
+            n_steps=6,
+        )
+        report("wasserstein_interp source returns (n_steps, n_bins)",
+               H_glide.shape == (6, analyzer.n_hist_bins),
+               f"shape = {H_glide.shape}")
+    except Exception as exc:
+        report("wasserstein_interp source", False, f"exception: {exc}")
+
+    # Latent decode
+    try:
+        H_latent = analyzer.get_histograms(
+            source="latent_interp", t1=0, t2=len(analyzer.ratios_list) - 1,
+            n_steps=6,
+        )
+        report("latent_interp source returns valid shape",
+               H_latent.shape == (6, analyzer.n_hist_bins),
+               f"shape = {H_latent.shape}")
+    except Exception as exc:
+        report("latent_interp source", False, f"exception: {exc}")
+
+    # Markov centroids + sample
+    try:
+        H_cent = analyzer.get_histograms(source="markov_centroids")
+        H_samp = analyzer.get_histograms(source="markov_sample", n_steps=8)
+        report("markov_centroids / markov_sample shapes",
+               H_cent.shape[1] == analyzer.n_hist_bins
+               and H_samp.shape == (8, analyzer.n_hist_bins),
+               f"cent = {H_cent.shape}, sample = {H_samp.shape}")
+    except Exception as exc:
+        report("markov_centroids / markov_sample", False, f"exception: {exc}")
+
+    # Optional MIDI render through analyzer.to_midi
+    if want_midi:
+        try:
+            outdir.mkdir(parents=True, exist_ok=True)
+            cwd = os.getcwd()
+            os.chdir(outdir)
+            try:
+                analyzer.to_midi(
+                    filename="hseq_observed", source="observed",
+                    duration_beats=0.5, n_peaks=4,
+                )
+            finally:
+                os.chdir(cwd)
+            report("analyzer.to_midi('observed') wrote a file",
+                   (outdir / "hseq_observed.mid").exists(),
+                   str(outdir / "hseq_observed.mid"))
+        except Exception as exc:
+            report("analyzer.to_midi('observed')", False, f"exception: {exc}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--skip-bt", action="store_true",
+                        help="Use only synthetic ratio sequences (skip "
+                             "compute_biotuner / signal pipeline).")
+    parser.add_argument("--no-midi", action="store_true",
+                        help="Skip MIDI rendering.")
+    parser.add_argument("--outdir", default="out_hseq",
+                        help="Directory for generated MIDI/SCL artifacts.")
+    args = parser.parse_args()
+
+    outdir = Path(args.outdir).resolve()
+
+    section("0 — Build a sequence")
+    ratios_list = synthetic_ratio_sequence(repeats=4)
+    info(f"synthetic ratio sequence: T = {len(ratios_list)} frames, "
+         f"~{len(ratios_list[0])} ratios per frame, alternating major/minor")
+
+    # Stateless encoders + bridge (no analyzer needed)
+    H = check_encoders(ratios_list)
+    check_bridge(H, outdir, want_midi=not args.no_midi)
+
+    # Build an analyzer
+    if args.skip_bt:
+        info("Building analyzer from ratio list (--skip-bt).")
+        analyzer = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list)
+    else:
+        try:
+            info("Building bt_list (this is the slow step — ~10 s).")
+            bts = build_bt_list(n_blocks=3)
+            analyzer = HarmonicSequenceAnalyzer.from_biotuner_list(
+                bts, tuning="peaks_ratios",
+            )
+            info(f"bt_list ready: {len(bts)} windows, "
+                 f"each with ~{len(bts[0].peaks) if bts[0].peaks is not None else 0} peaks")
+        except Exception as exc:
+            print(f"  {RED}!{RESET} compute_biotuner pipeline failed "
+                  f"({exc}). Falling back to ratio-list mode.")
+            analyzer = HarmonicSequenceAnalyzer.from_ratios_list(ratios_list)
+
+    # Approach-by-approach checks
+    check_markov(analyzer)
+    check_wasserstein(analyzer)
+    check_dmd(analyzer)
+    check_latent(analyzer)
+    check_topology(analyzer)
+    check_grammar(analyzer)
+    check_orchestrator_and_bridge(analyzer, outdir, want_midi=not args.no_midi)
+
+    # Final tally
+    section("Verdict")
+    n_pass = sum(1 for _, s, _ in RESULTS if s == "PASS")
+    n_fail = sum(1 for _, s, _ in RESULTS if s == "FAIL")
+    print(f"  {GREEN}{n_pass} passed{RESET}, {RED}{n_fail} failed{RESET} "
+          f"({n_pass + n_fail} total assertions)")
+    if n_fail:
+        print(f"\n  {RED}Failed assertions:{RESET}")
+        for name, status, msg in RESULTS:
+            if status == "FAIL":
+                print(f"    - {name}  ({msg})")
+    return 0 if n_fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds 7 scripts for testing and documenting the `harmonic_sequence` module
- **Zero changes to any existing source file**

## Scripts

| Script | What it does |
|---|---|
| `test_harmonic_sequence_capabilities.py` | 29 assertions across all 6 approaches |
| `generate_harmonic_sequence_paper_figures.py` | Basic demo figures (Figs 1–7, synthetic 3-regime cycle) |
| `generate_harmonic_sequence_advanced_cases.py` | 5 biosignal scenarios — event detection, fingerprinting, morphing (Figs 8–14) |
| `generate_harmonic_sequence_real_data.py` | Real 104-ch EEG as spatial harmonic sequence (Figs 15–17) |
| `generate_harmonic_sequence_real_tier1.py` | EEG sliding-window, cross-condition, dual-pathway, band-stratification (Figs 18–21) |
| `generate_harmonic_sequence_classical_apps.py` | Classical analogs for each approach — MIDI, OT geodesic, DMD forecast, latent embed, topology chaos, grammar stylometry (Figs 22–27) |
| `build_harmonic_sequence_paper_pdf.py` | Converts Markdown paper to PDF via `markdown_pdf` |

## Test plan
- [ ] `python scripts/test_harmonic_sequence_capabilities.py` — all 29 assertions pass
- [ ] Run `generate_*.py` scripts in order to regenerate figures (slow biotuner steps auto-cache to `docs/papers/_*_cache.npz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)